### PR TITLE
feat: rewrite Bash commands through gtkai proxy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "metadata": {
-    "description": "PostToolUse hook for Claude Code. Applies rule-based output reduction to Bash, git, grep, find, ls, Read, and MCP tools — truncation, grouping, and comment stripping depending on the command."
+    "description": "PreToolUse rewrite and PostToolUse filtering for Claude Code. Applies rule-based output reduction to Bash, git, grep, find, ls, Read, and MCP tools."
   },
   "owner": {
     "name": "jmeiracorbal",
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "gtk-ai",
-      "description": "PostToolUse hook that applies rule-based filtering to Bash, grep, find, ls, git, Read, and MCP tool output before it reaches the agent.",
-      "version": "0.3.3",
+      "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
+      "version": "0.4.0",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
-  "description": "PostToolUse hook that applies rule-based filtering to Bash, grep, find, ls, git, Read, and MCP tool output before it reaches the agent.",
-  "version": "0.3.3",
+  "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
+  "version": "0.4.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,17 @@ jobs:
           done
           echo "plugin manifest fields are consistent"
 
-      - name: Check hook script is executable
+      - name: Check hook scripts are executable
         run: |
-          mode=$(git ls-files -s plugin/scripts/gtkai-post-tool-use.sh | awk '{print $1}')
-          if [ "$mode" != "100755" ]; then
-            echo "plugin/scripts/gtkai-post-tool-use.sh is not executable in git (mode: $mode)"
-            echo "fix: git update-index --chmod=+x plugin/scripts/gtkai-post-tool-use.sh"
-            exit 1
-          fi
-          echo "hook script executable bit: ok"
+          failed=0
+          for f in plugin/scripts/gtkai-post-tool-use.sh plugin/scripts/gtkai-pre-tool-use.sh; do
+            mode=$(git ls-files -s "$f" | awk '{print $1}')
+            if [ "$mode" != "100755" ]; then
+              echo "$f is not executable in git (mode: $mode)"
+              echo "fix: git update-index --chmod=+x $f"
+              failed=1
+            else
+              echo "ok: $f"
+            fi
+          done
+          exit $failed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Two independent phases:
 
 Never collapse both phases into one. The plugin depends on the binary. The binary does not configure Claude Code.
 
-Target flow and remaining work: `ROADMAP.md`. Current `0.3.3` still filters Bash in `PostToolUse` only; `Rewrite()` is unused. That is the gap to close first.
+Target flow and remaining work: `ROADMAP.md`. `0.4.0` rewrites registered Bash commands in `PreToolUse` (`git status` → `gtkai git status`). `PostToolUse` still filters Read, MCP, and Bash commands that were not rewritten.
 
 ## Versions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Two independent phases:
 
 Never collapse both phases into one. The plugin depends on the binary. The binary does not configure Claude Code.
 
-Target flow and remaining work: `ROADMAP.md`. `0.4.0` rewrites registered Bash commands in `PreToolUse` (`git status` → `gtkai git status`). `PostToolUse` still filters Read, MCP, and Bash commands that were not rewritten.
+Target flow and remaining work: `ROADMAP.md`. `0.4.0` rewrites registered Bash commands in `PreToolUse` (`git status` → `gtkai git status`, same for `ls`/`find`/`grep`/`rg`). The proxy injects compact flags and filters stdout. `PostToolUse` still filters Read, MCP, and Bash commands that were not rewritten.
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # gtk-ai
 
 ![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go&logoColor=white)
-![Version](https://img.shields.io/badge/version-0.3.3-blue?style=flat)
+![Version](https://img.shields.io/badge/version-0.4.0-blue?style=flat)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin%20compatible-blueviolet?style=flat)
 ![Build](https://img.shields.io/badge/build-passing-brightgreen?style=flat)
 
 `gtk-ai` is a two-part integration for Claude Code:
 
-- the `gtkai` Go binary, which applies rule-based filtering to tool output
-- the Claude plugin, which registers the `PostToolUse` hook and invokes `gtkai`
+- the `gtkai` Go binary, which rewrites Bash commands before they run and filters their output
+- the Claude plugin, which registers `PreToolUse` and `PostToolUse` hooks and invokes `gtkai`
 
-It filters Bash, git, grep, find, ls, Read, and MCP tool output before it reaches the agent: truncation, grouping by extension, condensed formatting, and comment stripping depending on the command.
+Registered Bash commands are rewritten to `gtkai <cmd>` before execution. gtkai runs the real binary, injects compact flags when needed, and filters stdout. `Read` and MCP still go through `PostToolUse`.
 
 ```text
-Claude → Bash("find . -name '*.rs'")
-              ↓ executes
-         84 results, full paths (raw output)
-              ↓ PostToolUse hook → plugin script → gtkai hook-post
-         84 results / ext: .rs(84) / ...10 paths shown
+Claude → Bash("git status")
+              ↓ PreToolUse → gtkai hook-pre
+         command becomes gtkai git status
+              ↓ gtkai runs git status --porcelain -b
+         compact grouped status
               ↓
-         Claude receives filtered output (shorter, some detail dropped)
+         Claude receives filtered output
 ```
 
 ## Benchmark
@@ -92,9 +92,9 @@ Each module handles one command. All built-in modules ship with the binary.
 |---|---|---|
 | `find` | `find` | Truncates large result sets, groups by extension, shows summary |
 | `ls` | `ls` | Groups files by extension, separates dirs |
-| `git` | `git diff/log/status/branch` | Limits diff lines, truncates log, formats status |
+| `git` | `git diff/log/status/branch` | `git status` injects `--porcelain -b` and groups by state; other subcommands still post-filter |
 | `grep` | `grep` | Caps results, shows match count per file |
-| `gain` | — | SQLite analytics: tracks tokens in/out per command (not yet integrated in the hook) |
+| `gain` | — | SQLite analytics: recorded on each proxy run |
 
 ## Adding a module
 
@@ -116,7 +116,7 @@ func (m *Module) Name() string { return "mycommand" }
 
 func (m *Module) Rewrite(args []string) ([]string, bool) { return nil, false }
 
-func (m *Module) FilterOutput(output string) string { return output }
+func (m *Module) FilterOutput(args []string, output string) string { return output }
 
 func (m *Module) TokensBefore(output string) int { return registry.EstimateTokens(output) }
 
@@ -144,7 +144,9 @@ To identify which tools to exempt, check the tool names returned by your MCP ser
 ## Commands
 
 ```text
+gtkai hook-pre      PreToolUse handler — rewrites Bash commands to gtkai
 gtkai hook-post     PostToolUse handler — reads stdin JSON, writes filtered output
+gtkai git status    Proxy: run git through gtkai (other registered modules too)
 gtkai mcp-scan      List MCP server tools, suggest passthrough prefixes
 gtkai gain          Token savings analytics
 gtkai version       Print version
@@ -157,7 +159,10 @@ gtk-ai/
 ├── cmd/gtkai/              # binary entry point
 ├── internal/
 │   ├── registry/           # Module interface + Register() + EstimateTokens()
-│   └── hook/               # unified PostToolUse handler
+│   ├── shell/              # Bash command rewrite
+│   ├── proxy/              # execute + filter + gain
+│   ├── text/               # ANSI strip
+│   └── hook/               # PreToolUse and PostToolUse handlers
 ├── modules/
 │   ├── find/               # find output filter
 │   ├── ls/                 # ls output filter
@@ -166,7 +171,7 @@ gtk-ai/
 │   └── gain/               # SQLite token savings analytics
 └── plugin/
     ├── hooks/              # Claude plugin hook registration
-    └── scripts/            # script that invokes gtkai from Claude's hook system
+    └── scripts/            # scripts that invoke gtkai from Claude's hook system
 ```
 
 The `registry` package is the only shared dependency between modules. Modules never import each other.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Numbers from `go test ./internal/hook/... -v`. Token estimate: ~4 chars/token.
 
 | Input | Tokens before | Tokens after | Savings |
 |---|---:|---:|---:|
-| `find`: 150 paths | 1,050 | 714 | **32%** |
-| `grep`: 250 matches across 20 files | 3,820 | 3,059 | **20%** |
-| `git diff`: 400 lines | 3,185 | 2,386 | **25%** |
-| `git log`: 80 commits | 1,917 | 1,204 | **37%** |
+| `find`: 150 paths | 1,050 | 374 | **64%** |
+| `ls`: 70 entries | 262 | 65 | **75%** |
+| `grep`: 250 matches across 20 files | 3,820 | 3,360 | **12%** |
+| `git diff`: 400 lines | 3,185 | 813 | **74%** |
+| `git log`: 80 commits | 1,917 | 244 | **87%** |
 | `Read`: Go file, 100 commented vars | 1,346 | 348 | **74%** |
 | `Read`: plain text, 400 lines | 2,772 | 1,380 | **50%** |
 | MCP tool response — 5,200 chars | 1,300 | 758 | **42%** |
@@ -90,10 +91,10 @@ Each module handles one command. All built-in modules ship with the binary.
 
 | Module | Command | What it does |
 |---|---|---|
-| `find` | `find` | Truncates large result sets, groups by extension, shows summary |
-| `ls` | `ls` | Groups files by extension, separates dirs |
-| `git` | `git diff/log/status/branch` | `git status` injects `--porcelain -b` and groups by state; other subcommands still post-filter |
-| `grep` | `grep` | Caps results, shows match count per file |
+| `find` | `find` | Groups paths by directory, caps shown files, extension summary |
+| `ls` | `ls` | Injects `-l` + `LC_ALL=C` (and `-a` only if the user asked); compact to counts and samples; skips noise dirs |
+| `git` | `git diff/log/status/branch` | `status` injects `--porcelain -b`; `log` injects pretty-format and `-10`; `diff` strips headers and caps hunks |
+| `grep` / `rg` | `grep`, `rg` | Shared grouping by file with per-file and total caps; `grep` injects `-nH` |
 | `gain` | — | SQLite analytics: recorded on each proxy run |
 
 ## Adding a module
@@ -146,7 +147,7 @@ To identify which tools to exempt, check the tool names returned by your MCP ser
 ```text
 gtkai hook-pre      PreToolUse handler — rewrites Bash commands to gtkai
 gtkai hook-post     PostToolUse handler — reads stdin JSON, writes filtered output
-gtkai git status    Proxy: run git through gtkai (other registered modules too)
+gtkai git status    Proxy: run a registered command through gtkai (`ls`, `find`, `grep`, `rg`, `git`)
 gtkai mcp-scan      List MCP server tools, suggest passthrough prefixes
 gtkai gain          Token savings analytics
 gtkai version       Print version
@@ -159,6 +160,7 @@ gtk-ai/
 ├── cmd/gtkai/              # binary entry point
 ├── internal/
 │   ├── registry/           # Module interface + Register() + EstimateTokens()
+│   ├── matchgroup/         # shared grep/rg grouping
 │   ├── shell/              # Bash command rewrite
 │   ├── proxy/              # execute + filter + gain
 │   ├── text/               # ANSI strip

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,14 +73,14 @@ With the proxy, these modules can inject flags. That is what they cannot do toda
 
 | Module | Current problem | Fix with rewrite |
 |---|---|---|
-| `ls` | Reformats and **still lists every name**. `TestLsLargeOutputNotModified` documents that it never shortens. | Run `ls` with stable flags (`-la`, `LC_ALL=C`), compact to counts + N samples, skip noise dirs. |
+| `ls` | Done in `0.4.0`: `-l` + `LC_ALL=C`, `-a` only if requested, counts + samples, noise dirs skipped. | — |
 | `git status` | Expects porcelain. Claude runs the long format; the parser never matches. | Covered in the primary phase. |
-| `git diff` | Blind cut at 300 lines. | `--stat` + compact hunks (per-hunk cap), strip `index`/`+++`. |
-| `git log` | Cuts 50 verbose entries. | Inject `%h %s (%ar) <%an>` if the user did not pass `--pretty`/`--oneline`; default 10; honor `-n`. |
+| `git diff` | Done in `0.4.0`: strip `index`/`+++`/`---`, cap per hunk. | — |
+| `git log` | Done in `0.4.0`: inject `%h %s (%ar) <%an>` and `-10`; honor `--pretty`/`--oneline`/`-n`. | — |
 | `git branch` | Partial. | Filter remotes; cap. |
-| `grep` | 200 raw lines + a header. | Same contract as `rg`: group by file, caps. Shared parser. |
-| `rg` | Almost aligned. | `-A/-B` flags, pipelines. |
-| `find` | 100 paths + extension. | Group by directory, lower cap, do not inflate small outputs. |
+| `grep` | Done in `0.4.0`: same grouping as `rg`; injects `-nH`. | — |
+| `rg` | Grouping shared with `grep`. Pipelines rewrite the last stage. | — |
+| `find` | Done in `0.4.0`: group by directory, cap 50, small outputs unchanged. | — |
 | `Read` | Only `//` and `#` lines. | `/* */` blocks, more extensions. No “signatures only” mode (rtk aggressive: unsafe). |
 | `gain` | SQLite is ready; the hook never records. | Wired in the proxy runner (phase 1). |
 
@@ -130,13 +130,13 @@ Out of scope until the core and the runners cover a typical session: rtk TOML fi
 
 ## Current vs target
 
-| | gtk-ai 0.3.3 | Target |
+| | gtk-ai 0.4.0 | Remaining |
 |---|---|---|
-| Bash | `PostToolUse` filters stdout | `PreToolUse` rewrites to `gtkai …`; the binary runs and filters |
-| `Rewrite()` | Dead | Injects flags |
-| `Read` / MCP | `PostToolUse` | Kept |
-| `gain` | Does not record | Every proxy execution |
-| Commands | find, ls, git (4), grep, rg, Read, MCP | The same, corrected, then runners |
+| Bash | `PreToolUse` rewrites registered commands to `gtkai …`; the binary runs and filters | Drop Bash `PostToolUse` once coverage is trusted |
+| `Rewrite()` | Injects flags for `git status`, `git log`, `ls`, `grep` | Runners (`go test -json`) |
+| `Read` / MCP | `PostToolUse` | `/* */` on Read; native `Grep`/`Glob` |
+| `gain` | Every proxy execution | — |
+| Commands | find, ls, git (status/log/diff/branch), grep, rg, Read, MCP | `cat`/`head`/`tail`/`tree`, then runners |
 
 Filtering stays heuristic. No semantic compression.
 

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -1,5 +1,4 @@
-// gtk-ai — PostToolUse hook for Claude Code.
-// Applies rule-based output filtering to Bash, git, grep, find, ls, Read, and MCP tools.
+// gtk-ai — PreToolUse proxy and PostToolUse filter for Claude Code.
 // Binary: gtkai
 package main
 
@@ -8,10 +7,11 @@ import (
 	"os"
 
 	"github.com/jmeiracorbal/gtk-ai/internal/hook"
+	"github.com/jmeiracorbal/gtk-ai/internal/proxy"
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
 	"github.com/jmeiracorbal/gtk-ai/modules/gain"
 	"github.com/jmeiracorbal/gtk-ai/modules/mcpscan"
 
-	// Register all built-in modules
 	_ "github.com/jmeiracorbal/gtk-ai/modules/find"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
@@ -19,13 +19,15 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
 )
 
-const version = "0.3.3"
+const version = "0.4.0"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s
 
 Usage:
+  gtkai hook-pre             PreToolUse hook — rewrites Bash commands to gtkai
   gtkai hook-post            PostToolUse hook — reads stdin, writes filtered output
+  gtkai <module> [args...]   Run a registered command through the proxy
   gtkai mcp-scan             List tools from all MCP servers, suggest passthrough prefixes
   gtkai gain                 Show token savings analytics
   gtkai version              Print version
@@ -46,14 +48,24 @@ func main() {
 	case "version", "--version", "-v":
 		fmt.Printf("gtkai %s\n", version)
 
+	case "hook-pre":
+		bin, err := os.Executable()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gtkai hook-pre: %v\n", err)
+			os.Exit(1)
+		}
+		_, err = hook.RunPre(os.Stdin, os.Stdout, bin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gtkai hook-pre: %v\n", err)
+			os.Exit(1)
+		}
+
 	case "hook-post":
-		modified, err := hook.Run(os.Stdin, os.Stdout)
+		_, err := hook.Run(os.Stdin, os.Stdout)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "gtkai hook-post: %v\n", err)
 			os.Exit(1)
 		}
-		_ = modified
-		os.Exit(0)
 
 	case "mcp-scan":
 		if err := mcpscan.Run(); err != nil {
@@ -74,8 +86,11 @@ func main() {
 		}
 
 	default:
-		fmt.Fprintf(os.Stderr, "gtkai: unknown command %q\n\n", os.Args[1])
-		usage()
-		os.Exit(1)
+		if registry.Get(os.Args[1]) == nil {
+			fmt.Fprintf(os.Stderr, "gtkai: unknown command %q\n\n", os.Args[1])
+			usage()
+			os.Exit(1)
+		}
+		os.Exit(proxy.Run(os.Args[1], os.Args[2:]))
 	}
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -146,18 +146,10 @@ func TestFindEmptyOutput(t *testing.T) {
 }
 
 func TestFindSmallOutput(t *testing.T) {
-	// find always reformats output, even for small result sets
 	raw := "./main.go\n./go.mod\n"
-	modified, out := runHook(t, bashPayload("find . -name '*.go'", raw))
-	if !modified {
-		t.Fatal("find should always reformat output")
-	}
-	compressed := extractBashOutput(t, out)
-	if !strings.Contains(compressed, "2") {
-		t.Errorf("expected result count in output, got: %s", compressed)
-	}
-	if !strings.Contains(compressed, ".go") {
-		t.Errorf("expected extension in output, got: %s", compressed)
+	modified, _ := runHook(t, bashPayload("find . -name '*.go'", raw))
+	if modified {
+		t.Error("small find output should not be modified when reformatted result is larger")
 	}
 }
 
@@ -252,12 +244,15 @@ func TestGitDiffCompression(t *testing.T) {
 }
 
 func TestGitStatusSmallOutput(t *testing.T) {
-	// small status: reformatted result would be larger, hook should return original
 	raw := " M internal/hook/post_tool_use.go\n M README.md\n?? plugin/\n?? docs/\n"
 
-	modified, _ := runHook(t, bashPayload("git status", raw))
-	if modified {
-		t.Error("small git status should not be modified (reformatted result would be larger)")
+	modified, out := runHook(t, bashPayload("git status", raw))
+	if !modified {
+		return
+	}
+	compressed := extractBashOutput(t, out)
+	if registry.EstimateTokens(compressed) > registry.EstimateTokens(raw) {
+		t.Fatal("modified status must not use more tokens than raw")
 	}
 }
 
@@ -296,7 +291,6 @@ func TestGitStatusCompression(t *testing.T) {
 		t.Error("expected Untracked section")
 	}
 }
-
 
 func TestGitLogCompression(t *testing.T) {
 	var sb strings.Builder

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -170,9 +170,7 @@ func TestLsSmallOutput(t *testing.T) {
 	}
 }
 
-func TestLsLargeOutputNotModified(t *testing.T) {
-	// ls always lists all filenames — reformatted output is always longer than raw.
-	// The len(result) >= len(output) guard ensures the hook never expands output.
+func TestLsLargeOutputCompressed(t *testing.T) {
 	var sb strings.Builder
 	for i := 0; i < 40; i++ {
 		fmt.Fprintf(&sb, "handler_%02d.go\n", i)
@@ -185,9 +183,17 @@ func TestLsLargeOutputNotModified(t *testing.T) {
 	}
 	raw := sb.String()
 
-	modified, _ := runHook(t, bashPayload("ls", raw))
-	if modified {
-		t.Error("ls output should not be modified: reformatted result is always longer than raw")
+	modified, out := runHook(t, bashPayload("ls", raw))
+	if !modified {
+		t.Fatal("large ls output should compact to counts and samples")
+	}
+	compressed := extractBashOutput(t, out)
+	reportGain(t, "ls (70 entries)", raw, compressed)
+	if len(compressed) >= len(raw) {
+		t.Errorf("expected compressed ls output to be shorter (%d >= %d)", len(compressed), len(raw))
+	}
+	if !strings.Contains(compressed, "40") && !strings.Contains(compressed, "files") {
+		t.Errorf("expected file count, got: %s", compressed)
 	}
 }
 

--- a/internal/hook/post_tool_use.go
+++ b/internal/hook/post_tool_use.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/jmeiracorbal/gtk-ai/internal/registry"
-	gitmod "github.com/jmeiracorbal/gtk-ai/modules/git"
+	"github.com/jmeiracorbal/gtk-ai/internal/text"
 	readmod "github.com/jmeiracorbal/gtk-ai/modules/read"
 )
 
@@ -47,9 +47,9 @@ type hookOutput struct {
 }
 
 type hookSpecific struct {
-	HookEventName      string        `json:"hookEventName"`
-	UpdatedOutput      *string       `json:"updatedOutput,omitempty"`
-	UpdatedMCPOutput   []textContent `json:"updatedMCPToolOutput,omitempty"`
+	HookEventName    string        `json:"hookEventName"`
+	UpdatedOutput    *string       `json:"updatedOutput,omitempty"`
+	UpdatedMCPOutput []textContent `json:"updatedMCPToolOutput,omitempty"`
 }
 
 // ── MCP passthrough patterns ──────────────────────────────────────────────────
@@ -144,22 +144,11 @@ func filterBashOutput(command, output string) (string, bool) {
 	}
 
 	base := fields[0]
-	// Strip path prefix if any (e.g. /usr/bin/find → find)
 	if idx := strings.LastIndex(base, "/"); idx >= 0 {
 		base = base[idx+1:]
 	}
-
-	// Special case: git needs the subcommand
-	if base == "git" {
-		subcommand := ""
-		for _, f := range fields[1:] {
-			if !strings.HasPrefix(f, "-") {
-				subcommand = f
-				break
-			}
-		}
-		filtered := gitmod.FilterOutputWithArgs(subcommand, output)
-		return filtered, filtered != output
+	if base == "gtkai" {
+		return output, false
 	}
 
 	mod := registry.Get(base)
@@ -167,8 +156,10 @@ func filterBashOutput(command, output string) (string, bool) {
 		return output, false
 	}
 
-	filtered := mod.FilterOutput(output)
-	return filtered, filtered != output
+	stripped := text.StripANSI(output)
+	filtered := mod.FilterOutput(fields[1:], stripped)
+	shown := registry.NeverWorse(output, filtered)
+	return shown, shown != output
 }
 
 // ── MCP handler ───────────────────────────────────────────────────────────────

--- a/internal/hook/pre_test.go
+++ b/internal/hook/pre_test.go
@@ -1,0 +1,93 @@
+package hook_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/hook"
+)
+
+func TestPreRewritesGitStatus(t *testing.T) {
+	payload := `{"tool_name":"Bash","tool_input":{"command":"git status","description":"show status"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	var result struct {
+		HookSpecificOutput struct {
+			HookEventName string `json:"hookEventName"`
+			UpdatedInput  struct {
+				Command     string `json:"command"`
+				Description string `json:"description"`
+			} `json:"updatedInput"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.HookSpecificOutput.HookEventName != "PreToolUse" {
+		t.Fatalf("event %q", result.HookSpecificOutput.HookEventName)
+	}
+	if result.HookSpecificOutput.UpdatedInput.Command != "gtkai git status" {
+		t.Fatalf("command %q", result.HookSpecificOutput.UpdatedInput.Command)
+	}
+	if result.HookSpecificOutput.UpdatedInput.Description != "show status" {
+		t.Fatalf("description dropped: %q", result.HookSpecificOutput.UpdatedInput.Description)
+	}
+}
+
+func TestPreLeavesEcho(t *testing.T) {
+	payload := `{"tool_name":"Bash","tool_input":{"command":"echo hi"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || out.Len() != 0 {
+		t.Fatalf("echo must pass through, ok=%v out=%q", ok, out.String())
+	}
+}
+
+func TestPreLeavesGtkai(t *testing.T) {
+	payload := `{"tool_name":"Bash","tool_input":{"command":"gtkai git status"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("already proxied command must not rewrite")
+	}
+}
+
+func TestPreEmptyBin(t *testing.T) {
+	_, err := hook.RunPre(strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"git status"}}`), &bytes.Buffer{}, "")
+	if err == nil {
+		t.Fatal("empty gtkai path must fail")
+	}
+}
+
+func TestPreIgnoresRead(t *testing.T) {
+	payload := `{"tool_name":"Read","tool_input":{"file_path":"x.go"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("Read must not be rewritten")
+	}
+}
+
+func TestPostSkipsGtkaiCommand(t *testing.T) {
+	modified, _ := runHook(t, bashPayload("gtkai git status", strings.Repeat("M  file.go\n", 40)))
+	if modified {
+		t.Fatal("post-hook must not filter gtkai proxy output")
+	}
+}

--- a/internal/hook/pre_test.go
+++ b/internal/hook/pre_test.go
@@ -3,6 +3,7 @@ package hook_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -82,6 +83,24 @@ func TestPreIgnoresRead(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("Read must not be rewritten")
+	}
+}
+
+func TestPreRewritesRegisteredBash(t *testing.T) {
+	cases := []string{"ls -la", "find . -name '*.go'", "grep -n foo .", "rg foo"}
+	for _, cmd := range cases {
+		payload := fmt.Sprintf(`{"tool_name":"Bash","tool_input":{"command":%q}}`, cmd)
+		var out bytes.Buffer
+		ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatalf("%q: expected rewrite", cmd)
+		}
+		if !strings.Contains(out.String(), "gtkai "+strings.Fields(cmd)[0]) {
+			t.Fatalf("%q: rewritten command missing gtkai prefix: %s", cmd, out.String())
+		}
 	}
 }
 

--- a/internal/hook/pre_tool_use.go
+++ b/internal/hook/pre_tool_use.go
@@ -1,0 +1,74 @@
+package hook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/shell"
+)
+
+const stdinCap = 1 << 20
+
+type preOutput struct {
+	HookSpecificOutput preSpecific `json:"hookSpecificOutput"`
+}
+
+type preSpecific struct {
+	HookEventName string         `json:"hookEventName"`
+	UpdatedInput  map[string]any `json:"updatedInput"`
+}
+
+// RunPre reads a PreToolUse event, rewrites Bash commands to gtkai when a module matches.
+// gtkaiBin is the binary path inserted into the rewritten command.
+func RunPre(r io.Reader, w io.Writer, gtkaiBin string) (bool, error) {
+	if gtkaiBin == "" {
+		return false, fmt.Errorf("gtkai binary path is empty")
+	}
+
+	data, err := io.ReadAll(io.LimitReader(r, stdinCap+1))
+	if err != nil {
+		return false, fmt.Errorf("read stdin: %w", err)
+	}
+	if len(data) > stdinCap {
+		return false, nil
+	}
+	if len(data) == 0 {
+		return false, nil
+	}
+
+	var input hookInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		return false, nil
+	}
+	if input.ToolName != "Bash" {
+		return false, nil
+	}
+
+	var toolInput map[string]any
+	if err := json.Unmarshal(input.ToolInput, &toolInput); err != nil {
+		return false, nil
+	}
+	cmd, ok := toolInput["command"].(string)
+	if !ok || cmd == "" {
+		return false, nil
+	}
+
+	rewritten, changed := shell.Rewrite(cmd, gtkaiBin)
+	if !changed {
+		return false, nil
+	}
+
+	toolInput["command"] = rewritten
+	out, err := json.Marshal(preOutput{
+		HookSpecificOutput: preSpecific{
+			HookEventName: "PreToolUse",
+			UpdatedInput:  toolInput,
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("marshal: %w", err)
+	}
+	_, err = fmt.Fprintln(w, string(out))
+	return true, err
+}

--- a/internal/matchgroup/matchgroup.go
+++ b/internal/matchgroup/matchgroup.go
@@ -1,0 +1,144 @@
+// Package matchgroup groups grep/rg matches by file with shared caps.
+package matchgroup
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	maxTotalMatches   = 200
+	maxMatchesPerFile = 10
+	maxFiles          = 20
+	minLines          = 5
+)
+
+// Format groups match lines by file. Returns output unchanged when grouping
+// would not shrink the text or the set is too small to group.
+func Format(output string) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+
+	var nonempty []string
+	for _, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			nonempty = append(nonempty, l)
+		}
+	}
+
+	if len(nonempty) < minLines {
+		return output
+	}
+
+	byFile := parse(nonempty)
+
+	totalMatches := 0
+	for _, matches := range byFile.matches {
+		totalMatches += len(matches)
+	}
+
+	if totalMatches == 0 {
+		return output
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("🔍 %d matches in %d files\n\n", totalMatches, len(byFile.order)))
+
+	filesShown := 0
+	for _, file := range byFile.order {
+		if filesShown >= maxFiles {
+			remaining := len(byFile.order) - filesShown
+			sb.WriteString(fmt.Sprintf("... +%d more files\n", remaining))
+			break
+		}
+		matches := byFile.matches[file]
+		sb.WriteString(file)
+		sb.WriteString("\n")
+		limit := len(matches)
+		if limit > maxMatchesPerFile {
+			limit = maxMatchesPerFile
+		}
+		for _, l := range matches[:limit] {
+			sb.WriteString("  ")
+			sb.WriteString(l)
+			sb.WriteString("\n")
+		}
+		if len(matches) > maxMatchesPerFile {
+			sb.WriteString(fmt.Sprintf("  ... +%d more matches\n", len(matches)-maxMatchesPerFile))
+		}
+		sb.WriteString("\n")
+		filesShown++
+	}
+
+	if totalMatches > maxTotalMatches {
+		sb.WriteString(fmt.Sprintf("... [gtkai: %d total matches, output truncated]\n", totalMatches))
+	}
+
+	result := sb.String()
+	if len(result) >= len(output) {
+		return output
+	}
+	return result
+}
+
+type fileMatches struct {
+	order   []string
+	matches map[string][]string
+}
+
+func isMatchLine(l string) bool {
+	i := 0
+	for i < len(l) && l[i] >= '0' && l[i] <= '9' {
+		i++
+	}
+	if i == 0 || i >= len(l) {
+		return false
+	}
+	return l[i] == ':' || l[i] == '-'
+}
+
+func parse(lines []string) fileMatches {
+	result := fileMatches{matches: map[string][]string{}}
+
+	headingFormat := false
+	for _, l := range lines {
+		if isMatchLine(l) {
+			headingFormat = true
+			break
+		}
+	}
+
+	if headingFormat {
+		currentFile := ""
+		for _, l := range lines {
+			if isMatchLine(l) {
+				if currentFile != "" {
+					result.matches[currentFile] = append(result.matches[currentFile], l)
+				}
+			} else {
+				currentFile = l
+				if _, seen := result.matches[currentFile]; !seen {
+					result.order = append(result.order, currentFile)
+					result.matches[currentFile] = nil
+				}
+			}
+		}
+		return result
+	}
+
+	for _, l := range lines {
+		file := flatFile(l)
+		if _, seen := result.matches[file]; !seen {
+			result.order = append(result.order, file)
+		}
+		result.matches[file] = append(result.matches[file], l)
+	}
+	return result
+}
+
+func flatFile(line string) string {
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return ""
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,95 @@
+// Package proxy runs a registered module against a real command.
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+	"github.com/jmeiracorbal/gtk-ai/internal/text"
+	"github.com/jmeiracorbal/gtk-ai/modules/gain"
+)
+
+// Run executes name with args, filters stdout, records gain, and returns the child exit code.
+func Run(name string, args []string) int {
+	mod := registry.Get(name)
+	if mod == nil {
+		fmt.Fprintf(os.Stderr, "gtkai: unknown command %q\n", name)
+		return 1
+	}
+
+	execArgs := args
+	rewritten, didRewrite := mod.Rewrite(args)
+	if didRewrite {
+		execArgs = rewritten
+	}
+
+	start := time.Now()
+
+	var rawOut, execOut, execErr string
+	var execCode int
+	var execFail error
+
+	if didRewrite {
+		rawOut, _, _, _ = runCmd(name, args)
+		execOut, execErr, execCode, execFail = runCmd(name, execArgs)
+	} else {
+		execOut, execErr, execCode, execFail = runCmd(name, execArgs)
+		rawOut = execOut
+	}
+
+	elapsed := time.Since(start)
+
+	stripped := text.StripANSI(execOut)
+	filtered := mod.FilterOutput(execArgs, stripped)
+	shown := registry.NeverWorse(rawOut, filtered)
+
+	if _, werr := os.Stdout.WriteString(shown); werr != nil {
+		fmt.Fprintf(os.Stderr, "gtkai: write stdout: %v\n", werr)
+	}
+	if execErr != "" {
+		_, _ = os.Stderr.WriteString(execErr)
+	}
+
+	label := name
+	if len(args) > 0 {
+		label = name + " " + strings.Join(args, " ")
+	}
+	recordGain(label, rawOut, shown, elapsed)
+
+	if execFail != nil {
+		fmt.Fprintf(os.Stderr, "gtkai: %v\n", execFail)
+		return 1
+	}
+	return execCode
+}
+
+func runCmd(name string, args []string) (stdout, stderr string, code int, err error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = os.Stdin
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	code = 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+			err = nil
+		}
+	}
+	return outBuf.String(), errBuf.String(), code, err
+}
+
+func recordGain(cmd, raw, shown string, elapsed time.Duration) {
+	t, err := gain.Open()
+	if err != nil {
+		return
+	}
+	defer t.Close()
+	_ = t.Record(cmd, registry.EstimateTokens(raw), registry.EstimateTokens(shown), elapsed)
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -28,6 +28,8 @@ func Run(name string, args []string) int {
 		execArgs = rewritten
 	}
 
+	env := extraEnv(mod, execArgs)
+
 	start := time.Now()
 
 	var rawOut, execOut, execErr string
@@ -35,10 +37,10 @@ func Run(name string, args []string) int {
 	var execFail error
 
 	if didRewrite {
-		rawOut, _, _, _ = runCmd(name, args)
-		execOut, execErr, execCode, execFail = runCmd(name, execArgs)
+		rawOut, _, _, _ = runCmd(name, args, env)
+		execOut, execErr, execCode, execFail = runCmd(name, execArgs, env)
 	} else {
-		execOut, execErr, execCode, execFail = runCmd(name, execArgs)
+		execOut, execErr, execCode, execFail = runCmd(name, execArgs, env)
 		rawOut = execOut
 	}
 
@@ -68,9 +70,20 @@ func Run(name string, args []string) int {
 	return execCode
 }
 
-func runCmd(name string, args []string) (stdout, stderr string, code int, err error) {
+func extraEnv(mod registry.Module, args []string) []string {
+	inj, ok := mod.(registry.EnvInjector)
+	if !ok {
+		return nil
+	}
+	return inj.ExtraEnv(args)
+}
+
+func runCmd(name string, args []string, env []string) (stdout, stderr string, code int, err error) {
 	cmd := exec.Command(name, args...)
 	cmd.Stdin = os.Stdin
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -2,6 +2,7 @@ package proxy_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"github.com/jmeiracorbal/gtk-ai/modules/gain"
 
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
 )
 
 func TestRunGitStatus(t *testing.T) {
@@ -96,4 +98,59 @@ func TestRunUnknown(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit %d", code)
 	}
+}
+
+func TestRunLs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	for i := 0; i < 40; i++ {
+		name := filepath.Join(dir, fmt.Sprintf("handler_%02d.go", i))
+		if err := os.WriteFile(name, []byte("package p\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	out := captureStdout(t, func() int { return proxy.Run("ls", nil) })
+	if !strings.Contains(out, "files") {
+		t.Fatalf("expected compact ls, got %q", out)
+	}
+	if strings.Count(out, "handler_") > 12 {
+		t.Fatalf("expected sampled names, got %q", out)
+	}
+}
+
+func captureStdout(t *testing.T, fn func() int) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	code := fn()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Close()
+	if code != 0 {
+		t.Fatalf("exit %d, out %q", code, buf.String())
+	}
+	return buf.String()
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,99 @@
+package proxy_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/proxy"
+	"github.com/jmeiracorbal/gtk-ai/modules/gain"
+
+	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
+)
+
+func TestRunGitStatus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+	run("init", "-q")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "a.go")
+	run("commit", "-q", "-m", "init")
+	if err := os.WriteFile(filepath.Join(dir, "b.go"), []byte("package b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	code := proxy.Run("git", []string{"status"})
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Close()
+
+	if code != 0 {
+		t.Fatalf("exit %d", code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "* ") {
+		t.Fatalf("expected branch line, got %q", out)
+	}
+	if !strings.Contains(out, "Untracked") {
+		t.Fatalf("expected untracked group, got %q", out)
+	}
+
+	tr, err := gain.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr.Close()
+	s, err := tr.GetSummary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.TotalCommands != 1 {
+		t.Fatalf("gain records: %d", s.TotalCommands)
+	}
+}
+
+func TestRunUnknown(t *testing.T) {
+	code := proxy.Run("echo", []string{"hi"})
+	if code != 1 {
+		t.Fatalf("exit %d", code)
+	}
+}

--- a/internal/registry/never_worse_test.go
+++ b/internal/registry/never_worse_test.go
@@ -1,0 +1,19 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNeverWorse(t *testing.T) {
+	raw := strings.Repeat("a", 400)
+	if NeverWorse(raw, "ok") != "ok" {
+		t.Fatal("shorter filtered should win")
+	}
+	if NeverWorse("{}", "{\n  \"pretty\": true\n}") != "{}" {
+		t.Fatal("longer filtered should fall back to raw")
+	}
+	if NeverWorse("abcd", "wxyz") != "wxyz" {
+		t.Fatal("tie keeps filtered")
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -18,8 +18,8 @@ type Module interface {
 	Rewrite(args []string) ([]string, bool)
 
 	// FilterOutput applies heuristic pruning to command output before it reaches the agent.
-	// Returns the filtered output.
-	FilterOutput(output string) string
+	// args are the words after the module name (e.g. ["status", "-sb"] for git).
+	FilterOutput(args []string, output string) string
 
 	// TokensBefore estimates tokens in the original output.
 	TokensBefore(output string) int
@@ -60,4 +60,12 @@ func EstimateTokens(s string) int {
 		return 1
 	}
 	return n
+}
+
+// NeverWorse returns filtered, or raw when filtered would use more estimated tokens.
+func NeverWorse(raw, filtered string) string {
+	if EstimateTokens(filtered) > EstimateTokens(raw) {
+		return raw
+	}
+	return filtered
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -28,6 +28,12 @@ type Module interface {
 	TokensAfter(filtered string) int
 }
 
+// EnvInjector is implemented by modules that need extra environment variables
+// when the proxy executes the command.
+type EnvInjector interface {
+	ExtraEnv(args []string) []string
+}
+
 var modules = map[string]Module{}
 
 // Register adds a module to the registry. Called from module init().

--- a/internal/shell/rewrite.go
+++ b/internal/shell/rewrite.go
@@ -1,0 +1,389 @@
+// Package shell rewrites agent Bash commands to gtkai proxy invocations.
+package shell
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+type tokenKind int
+
+const (
+	tokWord tokenKind = iota
+	tokAnd
+	tokOr
+	tokSemi
+	tokPipe
+	tokPipeAnd
+)
+
+type token struct {
+	kind tokenKind
+	val  string
+}
+
+// Rewrite inserts gtkaiBin before a registered command.
+// gtkaiBin must be non-empty; the caller supplies it.
+func Rewrite(cmd, gtkaiBin string) (string, bool) {
+	if gtkaiBin == "" {
+		return "", false
+	}
+	if strings.Contains(cmd, "<<") || strings.Contains(cmd, "$(") || strings.Contains(cmd, "`") {
+		return "", false
+	}
+
+	toks, ok := tokenize(cmd)
+	if !ok || len(toks) == 0 {
+		return "", false
+	}
+
+	clauses := splitClauses(toks)
+	changed := false
+	var out []token
+	for i, cl := range clauses {
+		if i > 0 {
+			out = append(out, cl.sep)
+		}
+		rw, did := rewriteClause(cl.toks, gtkaiBin)
+		if did {
+			changed = true
+			out = append(out, rw...)
+		} else {
+			out = append(out, cl.toks...)
+		}
+	}
+	if !changed {
+		return "", false
+	}
+	return join(out), true
+}
+
+type clause struct {
+	sep  token
+	toks []token
+}
+
+func splitClauses(toks []token) []clause {
+	var clauses []clause
+	var cur []token
+	sep := token{}
+	first := true
+	flush := func() {
+		if len(cur) == 0 {
+			return
+		}
+		c := clause{toks: cur}
+		if !first {
+			c.sep = sep
+		}
+		clauses = append(clauses, c)
+		cur = nil
+		first = false
+	}
+	for _, t := range toks {
+		switch t.kind {
+		case tokAnd, tokOr, tokSemi:
+			flush()
+			sep = t
+			first = false
+			cur = nil
+		default:
+			cur = append(cur, t)
+		}
+	}
+	flush()
+	return clauses
+}
+
+func rewriteClause(toks []token, gtkaiBin string) ([]token, bool) {
+	stages, seps := splitPipeline(toks)
+	if len(stages) == 0 {
+		return nil, false
+	}
+	if len(stages) == 1 {
+		return rewriteSimple(stages[0], gtkaiBin)
+	}
+
+	last := stages[len(stages)-1]
+	name := commandName(last)
+	if name != "grep" && name != "rg" {
+		return nil, false
+	}
+	rw, ok := rewriteSimple(last, gtkaiBin)
+	if !ok {
+		return nil, false
+	}
+	var out []token
+	for i, st := range stages {
+		if i > 0 {
+			out = append(out, seps[i-1])
+		}
+		if i == len(stages)-1 {
+			out = append(out, rw...)
+		} else {
+			out = append(out, st...)
+		}
+	}
+	return out, true
+}
+
+func splitPipeline(toks []token) (stages [][]token, seps []token) {
+	var cur []token
+	for _, t := range toks {
+		if t.kind == tokPipe || t.kind == tokPipeAnd {
+			stages = append(stages, cur)
+			seps = append(seps, t)
+			cur = nil
+			continue
+		}
+		cur = append(cur, t)
+	}
+	stages = append(stages, cur)
+	return stages, seps
+}
+
+func rewriteSimple(toks []token, gtkaiBin string) ([]token, bool) {
+	words := wordVals(toks)
+	if len(words) == 0 {
+		return nil, false
+	}
+
+	i := 0
+	for i < len(words) {
+		w := words[i]
+		if isAssign(w) || w == "sudo" || w == "env" {
+			i++
+			continue
+		}
+		break
+	}
+	if i >= len(words) {
+		return nil, false
+	}
+
+	base := basename(words[i])
+	if base == "gtkai" {
+		return nil, false
+	}
+	if registry.Get(base) == nil {
+		return nil, false
+	}
+
+	out := make([]token, 0, len(toks)+2)
+	wi := 0
+	for _, t := range toks {
+		if t.kind != tokWord {
+			out = append(out, t)
+			continue
+		}
+		if wi == i {
+			out = append(out, token{kind: tokWord, val: gtkaiBin})
+			out = append(out, token{kind: tokWord, val: base})
+			wi++
+			continue
+		}
+		out = append(out, t)
+		wi++
+	}
+	return out, true
+}
+
+func commandName(toks []token) string {
+	words := wordVals(toks)
+	i := 0
+	for i < len(words) {
+		w := words[i]
+		if isAssign(w) || w == "sudo" || w == "env" {
+			i++
+			continue
+		}
+		break
+	}
+	if i >= len(words) {
+		return ""
+	}
+	return basename(words[i])
+}
+
+func wordVals(toks []token) []string {
+	var w []string
+	for _, t := range toks {
+		if t.kind == tokWord {
+			w = append(w, t.val)
+		}
+	}
+	return w
+}
+
+func isAssign(s string) bool {
+	eq := strings.IndexByte(s, '=')
+	if eq <= 0 {
+		return false
+	}
+	name := s[:eq]
+	if name[0] != '_' && (name[0] < 'A' || name[0] > 'Z') && (name[0] < 'a' || name[0] > 'z') {
+		return false
+	}
+	for _, c := range name[1:] {
+		if c != '_' && (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func basename(p string) string {
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+func join(toks []token) string {
+	var b strings.Builder
+	for i, t := range toks {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		switch t.kind {
+		case tokAnd:
+			b.WriteString("&&")
+		case tokOr:
+			b.WriteString("||")
+		case tokSemi:
+			b.WriteString(";")
+		case tokPipe:
+			b.WriteString("|")
+		case tokPipeAnd:
+			b.WriteString("|&")
+		default:
+			b.WriteString(shellQuote(t.val))
+		}
+	}
+	return b.String()
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	safe := true
+	for _, r := range s {
+		if r > 127 || !(unicode.IsLetter(r) || unicode.IsDigit(r) || strings.ContainsRune("/._-+=:@,.", r)) {
+			safe = false
+			break
+		}
+	}
+	if safe {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func tokenize(cmd string) ([]token, bool) {
+	var toks []token
+	i := 0
+	n := len(cmd)
+	for i < n {
+		for i < n && (cmd[i] == ' ' || cmd[i] == '\t' || cmd[i] == '\n') {
+			i++
+		}
+		if i >= n {
+			break
+		}
+		if cmd[i] == '>' || cmd[i] == '<' {
+			return nil, false
+		}
+		if cmd[i] == '&' {
+			if i+1 < n && cmd[i+1] == '&' {
+				toks = append(toks, token{kind: tokAnd})
+				i += 2
+				continue
+			}
+			return nil, false
+		}
+		if cmd[i] == '|' {
+			if i+1 < n && cmd[i+1] == '|' {
+				toks = append(toks, token{kind: tokOr})
+				i += 2
+				continue
+			}
+			if i+1 < n && cmd[i+1] == '&' {
+				toks = append(toks, token{kind: tokPipeAnd})
+				i += 2
+				continue
+			}
+			toks = append(toks, token{kind: tokPipe})
+			i++
+			continue
+		}
+		if cmd[i] == ';' {
+			toks = append(toks, token{kind: tokSemi})
+			i++
+			continue
+		}
+		word, next, ok := readWord(cmd, i)
+		if !ok {
+			return nil, false
+		}
+		toks = append(toks, token{kind: tokWord, val: word})
+		i = next
+	}
+	return toks, true
+}
+
+func readWord(s string, i int) (string, int, bool) {
+	var b strings.Builder
+	n := len(s)
+	for i < n {
+		c := s[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == ';' || c == '|' || c == '&' || c == '>' || c == '<' {
+			break
+		}
+		if c == '\\' {
+			if i+1 >= n {
+				return "", 0, false
+			}
+			b.WriteByte(s[i+1])
+			i += 2
+			continue
+		}
+		if c == '\'' {
+			i++
+			for i < n && s[i] != '\'' {
+				b.WriteByte(s[i])
+				i++
+			}
+			if i >= n {
+				return "", 0, false
+			}
+			i++
+			continue
+		}
+		if c == '"' {
+			i++
+			for i < n && s[i] != '"' {
+				if s[i] == '\\' && i+1 < n {
+					b.WriteByte(s[i+1])
+					i += 2
+					continue
+				}
+				b.WriteByte(s[i])
+				i++
+			}
+			if i >= n {
+				return "", 0, false
+			}
+			i++
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	if b.Len() == 0 {
+		return "", 0, false
+	}
+	return b.String(), i, true
+}

--- a/internal/shell/rewrite_test.go
+++ b/internal/shell/rewrite_test.go
@@ -3,8 +3,10 @@ package shell
 import (
 	"testing"
 
+	_ "github.com/jmeiracorbal/gtk-ai/modules/find"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
 )
 
@@ -79,5 +81,21 @@ func TestRewriteRedirectPass(t *testing.T) {
 	_, ok := Rewrite("git status > /tmp/out", "gtkai")
 	if ok {
 		t.Fatal("redirects must pass through")
+	}
+}
+
+func TestRewriteRegisteredModules(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"ls", "gtkai ls"},
+		{"ls -la /tmp", "gtkai ls -la /tmp"},
+		{"find . -name '*.go'", "gtkai find . -name '*.go'"},
+		{"grep -n foo src", "gtkai grep -n foo src"},
+		{"rg Error src", "gtkai rg Error src"},
+	}
+	for _, tc := range cases {
+		got, ok := Rewrite(tc.in, "gtkai")
+		if !ok || got != tc.want {
+			t.Errorf("%q: got %q ok=%v want %q", tc.in, got, ok, tc.want)
+		}
 	}
 }

--- a/internal/shell/rewrite_test.go
+++ b/internal/shell/rewrite_test.go
@@ -1,0 +1,83 @@
+package shell
+
+import (
+	"testing"
+
+	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
+)
+
+func TestRewriteGitStatus(t *testing.T) {
+	got, ok := Rewrite("git status", "gtkai")
+	if !ok || got != "gtkai git status" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
+
+func TestRewritePrefixes(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/usr/bin/git status", "gtkai git status"},
+		{"sudo git status", "sudo gtkai git status"},
+		{"VAR=1 git status", "VAR=1 gtkai git status"},
+		{"git -C /tmp status", "gtkai git -C /tmp status"},
+		{"sudo /usr/bin/git -C /tmp status", "sudo gtkai git -C /tmp status"},
+	}
+	for _, tc := range cases {
+		got, ok := Rewrite(tc.in, "gtkai")
+		if !ok || got != tc.want {
+			t.Errorf("%q: got %q ok=%v want %q", tc.in, got, ok, tc.want)
+		}
+	}
+}
+
+func TestRewriteUnregistered(t *testing.T) {
+	_, ok := Rewrite("echo hi", "gtkai")
+	if ok {
+		t.Fatal("echo should not be rewritten")
+	}
+}
+
+func TestRewriteAlreadyGtkai(t *testing.T) {
+	_, ok := Rewrite("gtkai git status", "gtkai")
+	if ok {
+		t.Fatal("already-proxied command should not be rewritten")
+	}
+}
+
+func TestRewriteEmptyBin(t *testing.T) {
+	_, ok := Rewrite("git status", "")
+	if ok {
+		t.Fatal("empty gtkai path must not rewrite")
+	}
+}
+
+func TestRewritePipelineLastGrep(t *testing.T) {
+	got, ok := Rewrite("cat foo | grep bar", "gtkai")
+	if !ok || got != "cat foo | gtkai grep bar" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
+
+func TestRewritePipelineGitPass(t *testing.T) {
+	_, ok := Rewrite("git status | head", "gtkai")
+	if ok {
+		t.Fatal("unsafe pipeline last stage must pass through")
+	}
+}
+
+func TestRewriteAnd(t *testing.T) {
+	got, ok := Rewrite("cd /tmp && git status", "gtkai")
+	if !ok || got != "cd /tmp && gtkai git status" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
+
+func TestRewriteRedirectPass(t *testing.T) {
+	_, ok := Rewrite("git status > /tmp/out", "gtkai")
+	if ok {
+		t.Fatal("redirects must pass through")
+	}
+}

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -1,0 +1,95 @@
+// Package text holds output guards used by the proxy and hooks.
+package text
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// StripANSI removes CSI/OSC sequences so filters parse plain text.
+func StripANSI(s string) string {
+	if !strings.ContainsRune(s, 0x1b) && !strings.ContainsRune(s, 0x9b) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == 0x1b {
+			i += size
+			if i >= len(s) {
+				break
+			}
+			n, nsize := utf8.DecodeRuneInString(s[i:])
+			switch n {
+			case '[':
+				i += nsize
+				i = skipWhile(s, i, func(c rune) bool {
+					return c < 0x40 || c > 0x7e
+				})
+				if i < len(s) {
+					_, sz := utf8.DecodeRuneInString(s[i:])
+					i += sz
+				}
+			case ']':
+				i += nsize
+				i = skipOSC(s, i)
+			case '(':
+				i += nsize
+				if i < len(s) {
+					_, sz := utf8.DecodeRuneInString(s[i:])
+					i += sz
+				}
+			default:
+				i += nsize
+			}
+			continue
+		}
+		if r == 0x9b {
+			i += size
+			i = skipWhile(s, i, func(c rune) bool {
+				return c < 0x40 || c > 0x7e
+			})
+			if i < len(s) {
+				_, sz := utf8.DecodeRuneInString(s[i:])
+				i += sz
+			}
+			continue
+		}
+		b.WriteRune(r)
+		i += size
+	}
+	return b.String()
+}
+
+func skipWhile(s string, i int, pred func(rune) bool) int {
+	for i < len(s) {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if !pred(r) {
+			return i
+		}
+		i += size
+	}
+	return i
+}
+
+func skipOSC(s string, i int) int {
+	for i < len(s) {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == 0x07 {
+			return i + size
+		}
+		if r == 0x1b {
+			j := i + size
+			if j < len(s) {
+				n, nsize := utf8.DecodeRuneInString(s[j:])
+				if n == '\\' {
+					return j + nsize
+				}
+			}
+		}
+		i += size
+	}
+	return i
+}

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -1,0 +1,18 @@
+package text
+
+import "testing"
+
+func TestStripANSI(t *testing.T) {
+	in := "\x1b[32mgreen\x1b[0m file.go"
+	got := StripANSI(in)
+	if got != "green file.go" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestStripANSIPlain(t *testing.T) {
+	in := "no color"
+	if StripANSI(in) != in {
+		t.Fatal("plain text should be unchanged")
+	}
+}

--- a/modules/find/find.go
+++ b/modules/find/find.go
@@ -23,7 +23,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 	return nil, false
 }
 
-func (m *Module) FilterOutput(output string) string {
+func (m *Module) FilterOutput(_ []string, output string) string {
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
 	var paths []string
 	for _, l := range lines {

--- a/modules/find/find.go
+++ b/modules/find/find.go
@@ -1,15 +1,19 @@
 // Module find: filters `find` output for Claude Code.
-// Strips noise, summarizes large result sets, groups by extension.
 package find
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/jmeiracorbal/gtk-ai/internal/registry"
 )
 
-const maxLines = 100
+const (
+	maxShown   = 50
+	minCompact = 8
+	maxExts    = 5
+)
 
 func init() {
 	registry.Register(&Module{})
@@ -34,52 +38,96 @@ func (m *Module) FilterOutput(_ []string, output string) string {
 	}
 
 	total := len(paths)
-	if total == 0 {
-		return "(no results)\n"
+	if total == 0 || total < minCompact {
+		return output
 	}
 
-	// Group by extension for summary
+	byDir := map[string][]string{}
+	var dirOrder []string
+	for _, p := range paths {
+		dir, name := splitPath(p)
+		if _, seen := byDir[dir]; !seen {
+			dirOrder = append(dirOrder, dir)
+		}
+		byDir[dir] = append(byDir[dir], name)
+	}
+	sort.Strings(dirOrder)
+
 	byExt := map[string]int{}
 	for _, p := range paths {
 		byExt[extOf(p)]++
 	}
 
-	truncated := false
-	shown := paths
-	if total > maxLines {
-		shown = paths[:maxLines]
-		truncated = true
-	}
-
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("📁 %d results", total))
-	if truncated {
-		sb.WriteString(fmt.Sprintf(" (showing %d)", maxLines))
-	}
-	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("%d files, %d dirs\n\n", total, len(dirOrder)))
 
-	// Extension summary
-	if len(byExt) > 0 {
-		parts := make([]string, 0, len(byExt))
-		for ext, n := range byExt {
-			if ext == "" {
-				ext = "no-ext"
-			}
-			parts = append(parts, fmt.Sprintf(".%s(%d)", ext, n))
+	shown := 0
+	for _, dir := range dirOrder {
+		if shown >= maxShown {
+			break
 		}
-		sb.WriteString(fmt.Sprintf("ext: %s\n", strings.Join(parts, " ")))
+		names := byDir[dir]
+		remaining := maxShown - shown
+		display := dir
+		if len(display) > 50 {
+			display = "..." + display[len(display)-47:]
+		}
+		if !strings.HasSuffix(display, "/") {
+			display += "/"
+		}
+		take := names
+		if len(names) > remaining {
+			take = names[:remaining]
+		}
+		sb.WriteString(display)
+		sb.WriteByte(' ')
+		sb.WriteString(strings.Join(take, " "))
+		sb.WriteByte('\n')
+		shown += len(take)
+	}
+	if shown < total {
+		sb.WriteString(fmt.Sprintf("+%d more\n", total-shown))
 	}
 
-	sb.WriteString("\n")
-	for _, p := range shown {
-		sb.WriteString(p)
-		sb.WriteString("\n")
-	}
-	if truncated {
-		sb.WriteString(fmt.Sprintf("... +%d more\n", total-maxLines))
+	if len(byExt) > 0 {
+		type kv struct {
+			ext string
+			n   int
+		}
+		exts := make([]kv, 0, len(byExt))
+		for ext, n := range byExt {
+			exts = append(exts, kv{ext, n})
+		}
+		sort.Slice(exts, func(i, j int) bool {
+			if exts[i].n != exts[j].n {
+				return exts[i].n > exts[j].n
+			}
+			return exts[i].ext < exts[j].ext
+		})
+		sb.WriteByte('\n')
+		sb.WriteString("ext: ")
+		n := len(exts)
+		if n > maxExts {
+			n = maxExts
+		}
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			label := exts[i].ext
+			if label == "" {
+				label = "no-ext"
+			}
+			sb.WriteString(fmt.Sprintf(".%s(%d)", label, exts[i].n))
+		}
+		sb.WriteByte('\n')
 	}
 
-	return sb.String()
+	result := sb.String()
+	if len(result) >= len(output) {
+		return output
+	}
+	return result
 }
 
 func (m *Module) TokensBefore(output string) int {
@@ -90,15 +138,26 @@ func (m *Module) TokensAfter(filtered string) int {
 	return registry.EstimateTokens(filtered)
 }
 
+func splitPath(p string) (dir, name string) {
+	slash := strings.LastIndex(p, "/")
+	if slash < 0 {
+		return ".", p
+	}
+	dir = p[:slash]
+	if dir == "" {
+		dir = "/"
+	}
+	return dir, p[slash+1:]
+}
+
 func extOf(path string) string {
-	// Use last component
 	slash := strings.LastIndex(path, "/")
 	name := path
 	if slash >= 0 {
 		name = path[slash+1:]
 	}
 	dot := strings.LastIndex(name, ".")
-	if dot < 0 || dot == len(name)-1 {
+	if dot <= 0 || dot == len(name)-1 {
 		return ""
 	}
 	return name[dot+1:]

--- a/modules/find/find_test.go
+++ b/modules/find/find_test.go
@@ -1,0 +1,45 @@
+package find
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFilterGroupsByDirectory(t *testing.T) {
+	m := &Module{}
+	var sb strings.Builder
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&sb, "./src/module_%02d/handler.go\n", i)
+		fmt.Fprintf(&sb, "./src/module_%02d/util.go\n", i)
+	}
+	raw := sb.String()
+	out := m.FilterOutput(nil, raw)
+	if out == raw {
+		t.Fatal("expected grouped output")
+	}
+	if !strings.Contains(out, "80 files") {
+		t.Fatalf("missing file count: %s", out)
+	}
+	if !strings.Contains(out, ".go(80)") {
+		t.Fatalf("missing ext: %s", out)
+	}
+	if strings.Count(out, "handler.go") > maxShown {
+		t.Fatalf("did not cap shown files: %s", out)
+	}
+}
+
+func TestFilterSmallUnchanged(t *testing.T) {
+	m := &Module{}
+	raw := "./main.go\n./go.mod\n"
+	if got := m.FilterOutput(nil, raw); got != raw {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFilterEmptyUnchanged(t *testing.T) {
+	m := &Module{}
+	if got := m.FilterOutput(nil, ""); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/modules/gain/gain.go
+++ b/modules/gain/gain.go
@@ -39,7 +39,11 @@ type Tracker struct {
 
 // Open opens (or creates) the gain database.
 func Open() (*Tracker, error) {
-	dir := filepath.Join(os.Getenv("HOME"), ".gtk-ai")
+	home := os.Getenv("HOME")
+	if home == "" {
+		return nil, fmt.Errorf("HOME is not set")
+	}
+	dir := filepath.Join(home, ".gtk-ai")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
@@ -94,10 +98,10 @@ func (t *Tracker) GetSummary() (Summary, error) {
 
 // CommandStat is per-command aggregated stats.
 type CommandStat struct {
-	Command    string
-	Count      int
+	Command     string
+	Count       int
 	TokensSaved int
-	AvgPct     float64
+	AvgPct      float64
 }
 
 // GetByCommand returns per-command stats sorted by tokens saved.

--- a/modules/git/diff_test.go
+++ b/modules/git/diff_test.go
@@ -1,0 +1,32 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilterDiffStripsHeadersAndCapsHunk(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("diff --git a/main.go b/main.go\n")
+	sb.WriteString("index abc..def 100644\n")
+	sb.WriteString("--- a/main.go\n")
+	sb.WriteString("+++ b/main.go\n")
+	sb.WriteString("@@ -1,3 +1,4 @@\n")
+	for i := 0; i < 150; i++ {
+		sb.WriteString("+added line\n")
+	}
+	raw := sb.String()
+	out := filterDiff(raw)
+	if strings.Contains(out, "index ") || strings.Contains(out, "+++ ") {
+		t.Fatalf("headers leaked: %s", out)
+	}
+	if !strings.Contains(out, "main.go") {
+		t.Fatalf("missing file: %s", out)
+	}
+	if !strings.Contains(out, "truncated") {
+		t.Fatalf("expected hunk cap: %s", out)
+	}
+	if strings.Count(out, "+added line") > maxHunkLines {
+		t.Fatalf("hunk not capped: %d", strings.Count(out, "+added line"))
+	}
+}

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -24,13 +24,23 @@ type Module struct{}
 func (m *Module) Name() string { return "git" }
 
 func (m *Module) Rewrite(args []string) ([]string, bool) {
-	return nil, false
+	globals, sub, rest, ok := splitGitArgs(args)
+	if !ok || sub != "status" {
+		return nil, false
+	}
+	if !usesCompactStatusPath(rest) {
+		return nil, false
+	}
+	out := append(append([]string{}, globals...), "status", "--porcelain", "-b")
+	return out, true
 }
 
-func (m *Module) FilterOutput(output string) string {
-	// We need the subcommand to know how to filter.
-	// Without it, return as-is — subcommand context is passed via FilterOutputWithArgs.
-	return output
+func (m *Module) FilterOutput(args []string, output string) string {
+	_, sub, _, ok := splitGitArgs(args)
+	if !ok {
+		return output
+	}
+	return FilterOutputWithArgs(sub, output)
 }
 
 // FilterOutputWithArgs filters git output based on the subcommand.
@@ -83,22 +93,47 @@ func filterStatus(output string) string {
 		return "nothing to commit, working tree clean\n"
 	}
 
+	if !isPorcelainStatus(lines) {
+		if len(lines) > maxStatusLines {
+			return strings.Join(lines[:maxStatusLines], "\n") + fmt.Sprintf("\n... +%d lines\n", len(lines)-maxStatusLines)
+		}
+		return output
+	}
+
+	var branch string
 	var modified, untracked, staged []string
 	for _, l := range lines {
+		if strings.HasPrefix(l, "##") {
+			branch = strings.TrimSpace(strings.TrimPrefix(l, "##"))
+			continue
+		}
 		if len(l) < 2 {
 			continue
 		}
+		xy := l[:2]
+		path := ""
+		if len(l) > 2 {
+			path = strings.TrimSpace(l[2:])
+		}
 		switch {
-		case strings.HasPrefix(l, "A ") || strings.HasPrefix(l, "M "):
-			staged = append(staged, strings.TrimSpace(l[2:]))
-		case strings.HasPrefix(l, " M"):
-			modified = append(modified, strings.TrimSpace(l[2:]))
-		case strings.HasPrefix(l, "??"):
-			untracked = append(untracked, strings.TrimSpace(l[3:]))
+		case xy == "??":
+			untracked = append(untracked, path)
+		case xy[0] != ' ' && xy[0] != '?':
+			staged = append(staged, path)
+			if xy[1] != ' ' && xy[1] != '?' {
+				modified = append(modified, path)
+			}
+		case xy[1] != ' ' && xy[1] != '?':
+			modified = append(modified, path)
 		}
 	}
 
 	var sb strings.Builder
+	if branch != "" {
+		sb.WriteString("* ")
+		sb.WriteString(branch)
+		sb.WriteString("\n")
+	}
 	if len(staged) > 0 {
 		sb.WriteString(fmt.Sprintf("Staged (%d): %s\n", len(staged), strings.Join(staged, ", ")))
 	}
@@ -112,17 +147,95 @@ func filterStatus(output string) string {
 			sb.WriteString(fmt.Sprintf("Untracked (%d): %s\n", len(untracked), strings.Join(untracked, ", ")))
 		}
 	}
-	if sb.Len() == 0 {
-		if len(lines) > maxStatusLines {
-			return strings.Join(lines[:maxStatusLines], "\n") + fmt.Sprintf("\n... +%d lines\n", len(lines)-maxStatusLines)
+	if len(staged)+len(modified)+len(untracked) == 0 {
+		if branch != "" {
+			sb.WriteString("clean — nothing to commit\n")
+			return sb.String()
 		}
 		return output
 	}
-	result := sb.String()
-	if len(result) >= len(output) {
-		return output
+	return sb.String()
+}
+
+func isPorcelainStatus(lines []string) bool {
+	sawEntry := false
+	for _, l := range lines {
+		if l == "" {
+			continue
+		}
+		if strings.HasPrefix(l, "##") {
+			continue
+		}
+		if len(l) < 2 || !isPorcelainCode(l[0]) || !isPorcelainCode(l[1]) {
+			return false
+		}
+		sawEntry = true
 	}
-	return result
+	return sawEntry || hasBranchHeader(lines)
+}
+
+func hasBranchHeader(lines []string) bool {
+	for _, l := range lines {
+		if strings.HasPrefix(l, "##") {
+			return true
+		}
+	}
+	return false
+}
+
+func isPorcelainCode(c byte) bool {
+	switch c {
+	case ' ', 'M', 'A', 'D', 'R', 'C', 'U', 'T', '?', '!':
+		return true
+	default:
+		return false
+	}
+}
+
+func splitGitArgs(args []string) (globals []string, sub string, rest []string, ok bool) {
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		switch {
+		case a == "-C" || a == "-c" || a == "--git-dir" || a == "--work-tree":
+			if i+1 >= len(args) {
+				return nil, "", nil, false
+			}
+			globals = append(globals, a, args[i+1])
+			i += 2
+		case strings.HasPrefix(a, "--git-dir=") || strings.HasPrefix(a, "--work-tree="):
+			globals = append(globals, a)
+			i++
+		case a == "--no-pager" || a == "--no-optional-locks" || a == "--bare" || a == "--literal-pathspecs":
+			globals = append(globals, a)
+			i++
+		default:
+			if strings.HasPrefix(a, "-") {
+				return nil, "", nil, false
+			}
+			return globals, a, args[i+1:], true
+		}
+	}
+	return globals, "", nil, false
+}
+
+func usesCompactStatusPath(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	sawBranch := false
+	for _, a := range args {
+		switch a {
+		case "-b", "--branch":
+			sawBranch = true
+		case "-sb", "-bs":
+			return true
+		case "-s", "--short":
+		default:
+			return false
+		}
+	}
+	return sawBranch
 }
 
 func filterBranch(output string) string {

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -4,15 +4,20 @@ package git
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmeiracorbal/gtk-ai/internal/registry"
 )
 
 const (
-	maxDiffLines   = 300
-	maxLogEntries  = 50
-	maxStatusLines = 100
+	maxDiffLines    = 300
+	maxHunkLines    = 100
+	maxLogDefault   = 10
+	maxLogUserFmt   = 50
+	maxLogLineWidth = 80
+	maxStatusLines  = 100
+	prettyLogFmt    = "%h %s (%ar) <%an>"
 )
 
 func init() {
@@ -25,31 +30,54 @@ func (m *Module) Name() string { return "git" }
 
 func (m *Module) Rewrite(args []string) ([]string, bool) {
 	globals, sub, rest, ok := splitGitArgs(args)
-	if !ok || sub != "status" {
+	if !ok {
 		return nil, false
 	}
-	if !usesCompactStatusPath(rest) {
+	switch sub {
+	case "status":
+		if !usesCompactStatusPath(rest) {
+			return nil, false
+		}
+		out := append(append([]string{}, globals...), "status", "--porcelain", "-b")
+		return out, true
+	case "log":
+		return rewriteLog(globals, rest)
+	default:
 		return nil, false
 	}
-	out := append(append([]string{}, globals...), "status", "--porcelain", "-b")
+}
+
+func rewriteLog(globals, rest []string) ([]string, bool) {
+	hasFmt := hasLogFormat(rest)
+	_, hasLimit := parseLogLimit(rest)
+	if hasFmt && hasLimit {
+		return nil, false
+	}
+	out := append(append([]string{}, globals...), "log")
+	if !hasFmt {
+		out = append(out, "--pretty=format:"+prettyLogFmt)
+	}
+	if !hasLimit {
+		if hasFmt {
+			out = append(out, "-50")
+		} else {
+			out = append(out, "-10")
+		}
+	}
+	out = append(out, rest...)
 	return out, true
 }
 
 func (m *Module) FilterOutput(args []string, output string) string {
-	_, sub, _, ok := splitGitArgs(args)
+	_, sub, rest, ok := splitGitArgs(args)
 	if !ok {
 		return output
 	}
-	return FilterOutputWithArgs(sub, output)
-}
-
-// FilterOutputWithArgs filters git output based on the subcommand.
-func FilterOutputWithArgs(subcommand, output string) string {
-	switch subcommand {
+	switch sub {
 	case "diff":
 		return filterDiff(output)
 	case "log":
-		return filterLog(output)
+		return filterLog(rest, output)
 	case "status":
 		return filterStatus(output)
 	case "branch":
@@ -60,31 +88,210 @@ func FilterOutputWithArgs(subcommand, output string) string {
 }
 
 func filterDiff(output string) string {
-	lines := strings.Split(output, "\n")
-	if len(lines) <= maxDiffLines {
-		return output
+	if !strings.Contains(output, "diff --git") && !strings.Contains(output, "@@") {
+		return capLines(output, maxDiffLines)
 	}
+
 	var sb strings.Builder
-	for _, l := range lines[:maxDiffLines] {
-		sb.WriteString(l)
-		sb.WriteString("\n")
+	hunkShown := 0
+	hunkSkipped := 0
+	inHunk := false
+	totalLines := 0
+	truncated := false
+
+	flushSkip := func() {
+		if hunkSkipped > 0 {
+			fmt.Fprintf(&sb, " ... (%d lines truncated)\n", hunkSkipped)
+			truncated = true
+			hunkSkipped = 0
+		}
 	}
-	sb.WriteString(fmt.Sprintf("... +%d lines truncated (use git diff <file> for specific files)\n", len(lines)-maxDiffLines))
-	return sb.String()
+
+	for _, line := range strings.Split(output, "\n") {
+		if totalLines >= maxDiffLines {
+			truncated = true
+			break
+		}
+		switch {
+		case strings.HasPrefix(line, "diff --git"):
+			flushSkip()
+			file := diffFile(line)
+			sb.WriteByte('\n')
+			sb.WriteString(file)
+			sb.WriteByte('\n')
+			inHunk = true
+			hunkShown = 0
+			totalLines++
+		case strings.HasPrefix(line, "index ") || strings.HasPrefix(line, "--- ") ||
+			strings.HasPrefix(line, "+++ ") || strings.HasPrefix(line, "new file") ||
+			strings.HasPrefix(line, "deleted file") || strings.HasPrefix(line, "old mode") ||
+			strings.HasPrefix(line, "new mode"):
+			continue
+		case strings.HasPrefix(line, "@@"):
+			flushSkip()
+			sb.WriteByte(' ')
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+			inHunk = true
+			hunkShown = 0
+			totalLines++
+		case inHunk && (strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") || strings.HasPrefix(line, " ")):
+			if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+				continue
+			}
+			if hunkShown < maxHunkLines {
+				sb.WriteByte(' ')
+				sb.WriteString(line)
+				sb.WriteByte('\n')
+				hunkShown++
+				totalLines++
+			} else {
+				hunkSkipped++
+			}
+		}
+	}
+	flushSkip()
+	if truncated {
+		sb.WriteString("... (more changes truncated)\n")
+	}
+	result := sb.String()
+	if result == "" || len(result) >= len(output) {
+		return capLines(output, maxDiffLines)
+	}
+	return result
 }
 
-func filterLog(output string) string {
-	// Each log entry starts with "commit "
-	entries := splitLogEntries(output)
-	if len(entries) <= maxLogEntries {
+func diffFile(line string) string {
+	if i := strings.Index(line, " b/"); i >= 0 {
+		return line[i+3:]
+	}
+	fields := strings.Fields(line)
+	if len(fields) > 0 {
+		return fields[len(fields)-1]
+	}
+	return line
+}
+
+func capLines(output string, max int) string {
+	lines := strings.Split(output, "\n")
+	if len(lines) <= max {
 		return output
 	}
-	var sb strings.Builder
-	for _, e := range entries[:maxLogEntries] {
-		sb.WriteString(e)
+	return strings.Join(lines[:max], "\n") + fmt.Sprintf("\n... +%d lines truncated\n", len(lines)-max)
+}
+
+func filterLog(args []string, output string) string {
+	userFmt := hasLogFormat(args)
+	userN, hasLimit := parseLogLimit(args)
+	limit := maxLogDefault
+	if hasLimit {
+		limit = userN
+	} else if userFmt {
+		limit = maxLogUserFmt
 	}
-	sb.WriteString(fmt.Sprintf("... +%d commits truncated\n", len(entries)-maxLogEntries))
-	return sb.String()
+
+	if looksLikeVerboseLog(output) {
+		entries := splitLogEntries(output)
+		max := limit
+		if hasLimit && userN >= len(entries) {
+			max = len(entries)
+		}
+		if len(entries) <= max {
+			return output
+		}
+		var sb strings.Builder
+		for _, e := range entries[:max] {
+			sb.WriteString(e)
+		}
+		sb.WriteString(fmt.Sprintf("... +%d commits truncated\n", len(entries)-max))
+		return sb.String()
+	}
+
+	var lines []string
+	for _, l := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		lines = append(lines, truncateLine(l, maxLogLineWidth))
+	}
+	max := limit
+	if hasLimit {
+		max = len(lines)
+	}
+	if len(lines) <= max {
+		return strings.Join(lines, "\n") + "\n"
+	}
+	return strings.Join(lines[:max], "\n") + fmt.Sprintf("\n... +%d commits truncated\n", len(lines)-max)
+}
+
+func looksLikeVerboseLog(output string) bool {
+	for _, l := range strings.Split(output, "\n") {
+		if l == "" {
+			continue
+		}
+		return strings.HasPrefix(l, "commit ")
+	}
+	return false
+}
+
+func truncateLine(s string, width int) string {
+	if width <= 0 || len(s) <= width {
+		return s
+	}
+	return s[:width]
+}
+
+func hasLogFormat(args []string) bool {
+	for _, a := range args {
+		if a == "--oneline" || strings.HasPrefix(a, "--pretty") || strings.HasPrefix(a, "--format") {
+			return true
+		}
+	}
+	return false
+}
+
+func parseLogLimit(args []string) (int, bool) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "-n" || a == "--max-count" {
+			if i+1 >= len(args) {
+				return 0, true
+			}
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil {
+				return 0, true
+			}
+			return n, true
+		}
+		if rest, ok := strings.CutPrefix(a, "--max-count="); ok {
+			n, err := strconv.Atoi(rest)
+			if err != nil {
+				return 0, true
+			}
+			return n, true
+		}
+		if strings.HasPrefix(a, "-n") && len(a) > 2 && isDigits(a[2:]) {
+			n, _ := strconv.Atoi(a[2:])
+			return n, true
+		}
+		if len(a) > 1 && a[0] == '-' && a[1] != '-' && isDigits(a[1:]) {
+			n, _ := strconv.Atoi(a[1:])
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func filterStatus(output string) string {

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
 )
 
 func TestFilterStatusStagedVsModified(t *testing.T) {
@@ -66,11 +68,10 @@ func TestFilterStatusUntrackedTruncated(t *testing.T) {
 }
 
 func TestFilterStatusLengthGuard(t *testing.T) {
-	// small input: reformatted result may be longer → guard returns original
 	raw := "M  a.go\n M b.go\nA  c.go\n"
 	out := filterStatus(raw)
-	// either the guard kicked in (returns raw) or result is shorter — never longer
-	if len(out) > len(raw) {
-		t.Errorf("filterStatus should never return output longer than input: %d > %d", len(out), len(raw))
+	shown := registry.NeverWorse(raw, out)
+	if registry.EstimateTokens(shown) > registry.EstimateTokens(raw) {
+		t.Errorf("NeverWorse should never return more tokens than input")
 	}
 }

--- a/modules/git/rewrite_test.go
+++ b/modules/git/rewrite_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -47,6 +48,48 @@ func TestRewriteNonStatus(t *testing.T) {
 	_, ok := m.Rewrite([]string{"diff"})
 	if ok {
 		t.Fatal("diff must not inject status flags")
+	}
+}
+
+func TestRewriteLogInjectsPretty(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"log"})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	want := []string{"log", "--pretty=format:%h %s (%ar) <%an>", "-10"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestRewriteLogHonorsUserFormatAndLimit(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"log", "--oneline", "-n", "20"})
+	if ok {
+		t.Fatal("user format and limit must not be rewritten")
+	}
+}
+
+func TestRewriteLogInjectsLimitForOneline(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"log", "--oneline"})
+	if !ok {
+		t.Fatal("expected -50 when user passed format without limit")
+	}
+	if !reflect.DeepEqual(got, []string{"log", "-50", "--oneline"}) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestFilterLogDefaultCap(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 30; i++ {
+		fmt.Fprintf(&sb, "commit abc%04d\nAuthor: Dev <dev@example.com>\n\n    fix %d\n\n", i, i)
+	}
+	out := filterLog(nil, sb.String())
+	if strings.Count(out, "commit ") != 10 {
+		t.Fatalf("expected 10 commits, got %d\n%s", strings.Count(out, "commit "), out)
 	}
 }
 

--- a/modules/git/rewrite_test.go
+++ b/modules/git/rewrite_test.go
@@ -1,0 +1,78 @@
+package git
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRewriteStatusInjectsPorcelain(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"status"})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	want := []string{"status", "--porcelain", "-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestRewriteStatusKeepsGlobals(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"-C", "/tmp", "status"})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	want := []string{"-C", "/tmp", "status", "--porcelain", "-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestRewriteStatusSkipsExplicitFormat(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"status", "--porcelain"})
+	if ok {
+		t.Fatal("user --porcelain must not be replaced")
+	}
+	_, ok = m.Rewrite([]string{"status", "--long"})
+	if ok {
+		t.Fatal("user --long must not be replaced")
+	}
+}
+
+func TestRewriteNonStatus(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"diff"})
+	if ok {
+		t.Fatal("diff must not inject status flags")
+	}
+}
+
+func TestRewriteIncompleteGlobal(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"-C"})
+	if ok {
+		t.Fatal("incomplete -C must not rewrite")
+	}
+}
+
+func TestFilterStatusPorcelainBranch(t *testing.T) {
+	raw := "## main...origin/main\n M a.go\nA  b.go\n?? c.go\n"
+	out := filterStatus(raw)
+	if !strings.Contains(out, "* main...origin/main") {
+		t.Fatalf("expected branch, got %q", out)
+	}
+	if !strings.Contains(out, "Staged") || !strings.Contains(out, "Modified") || !strings.Contains(out, "Untracked") {
+		t.Fatalf("expected groups, got %q", out)
+	}
+}
+
+func TestFilterStatusPorcelainClean(t *testing.T) {
+	raw := "## main\n"
+	out := filterStatus(raw)
+	if !strings.Contains(out, "* main") || !strings.Contains(out, "clean") {
+		t.Fatalf("got %q", out)
+	}
+}

--- a/modules/grep/grep.go
+++ b/modules/grep/grep.go
@@ -23,7 +23,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 	return nil, false
 }
 
-func (m *Module) FilterOutput(output string) string {
+func (m *Module) FilterOutput(_ []string, output string) string {
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
 	var matches []string
 	for _, l := range lines {

--- a/modules/grep/grep.go
+++ b/modules/grep/grep.go
@@ -1,15 +1,12 @@
 // Module grep: filters `grep` output for Claude Code.
-// Truncates large result sets, summarizes by file.
 package grep
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/jmeiracorbal/gtk-ai/internal/matchgroup"
 	"github.com/jmeiracorbal/gtk-ai/internal/registry"
 )
-
-const maxLines = 200
 
 func init() {
 	registry.Register(&Module{})
@@ -20,49 +17,30 @@ type Module struct{}
 func (m *Module) Name() string { return "grep" }
 
 func (m *Module) Rewrite(args []string) ([]string, bool) {
-	return nil, false
+	if hasArg(args, "--help") {
+		return nil, false
+	}
+	if hasShortOrLong(args, 'c', "--count") || hasShortOrLong(args, 'l', "--files-with-matches") ||
+		hasArg(args, "-L") || hasArg(args, "--files-without-match") ||
+		hasShortOrLong(args, 'o', "--only-matching") {
+		return nil, false
+	}
+
+	var extra []string
+	if !hasShortOrLong(args, 'n', "--line-number") {
+		extra = append(extra, "-n")
+	}
+	if !hasShortOrLong(args, 'H', "--with-filename") {
+		extra = append(extra, "-H")
+	}
+	if len(extra) == 0 {
+		return nil, false
+	}
+	return append(extra, args...), true
 }
 
 func (m *Module) FilterOutput(_ []string, output string) string {
-	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
-	var matches []string
-	for _, l := range lines {
-		if strings.TrimSpace(l) != "" {
-			matches = append(matches, l)
-		}
-	}
-
-	total := len(matches)
-	if total == 0 {
-		return "(no matches)\n"
-	}
-
-	// Count matches per file
-	byFile := map[string]int{}
-	for _, l := range matches {
-		file := fileOf(l)
-		byFile[file]++
-	}
-
-	truncated := false
-	shown := matches
-	if total > maxLines {
-		shown = matches[:maxLines]
-		truncated = true
-	}
-
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("🔍 %d matches in %d files\n\n", total, len(byFile)))
-
-	for _, l := range shown {
-		sb.WriteString(l)
-		sb.WriteString("\n")
-	}
-	if truncated {
-		sb.WriteString(fmt.Sprintf("... +%d lines truncated\n", total-maxLines))
-	}
-
-	return sb.String()
+	return matchgroup.Format(output)
 }
 
 func (m *Module) TokensBefore(output string) int {
@@ -73,11 +51,25 @@ func (m *Module) TokensAfter(filtered string) int {
 	return registry.EstimateTokens(filtered)
 }
 
-// fileOf extracts the filename from a grep -n line (file:line:content).
-func fileOf(line string) string {
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) > 0 {
-		return parts[0]
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
 	}
-	return ""
+	return false
+}
+
+func hasShortOrLong(args []string, short byte, long string) bool {
+	for _, a := range args {
+		if a == long || strings.HasPrefix(a, long+"=") {
+			return true
+		}
+		if len(a) >= 2 && a[0] == '-' && a[1] != '-' {
+			if strings.IndexByte(a, short) >= 0 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/modules/grep/grep_test.go
+++ b/modules/grep/grep_test.go
@@ -1,0 +1,55 @@
+package grep
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRewriteInjectsNH(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"foo", "."})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	if len(got) < 3 || got[0] != "-n" || got[1] != "-H" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestRewriteSkipsWhenPresent(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"-nH", "foo", "."})
+	if ok {
+		t.Fatal("already has -nH")
+	}
+}
+
+func TestRewriteSkipsCount(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"-c", "foo"})
+	if ok {
+		t.Fatal("count mode must not rewrite")
+	}
+}
+
+func TestFilterGroupsLikeRg(t *testing.T) {
+	m := &Module{}
+	var sb strings.Builder
+	for i := 0; i < 15; i++ {
+		for j := 0; j < 12; j++ {
+			fmt.Fprintf(&sb, "src/file_%02d.go:%d:    return fmt.Errorf(\"error %d\")\n", i, j+1, j)
+		}
+	}
+	raw := sb.String()
+	out := m.FilterOutput(nil, raw)
+	if out == raw {
+		t.Fatal("expected grouped output")
+	}
+	if !strings.Contains(out, "180 matches") {
+		t.Fatalf("got %s", out)
+	}
+	if !strings.Contains(out, "15 files") {
+		t.Fatalf("got %s", out)
+	}
+}

--- a/modules/ls/ls.go
+++ b/modules/ls/ls.go
@@ -1,13 +1,37 @@
 // Module ls: filters `ls` output for Claude Code.
-// Removes noise, groups by type, adds size suffixes.
 package ls
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jmeiracorbal/gtk-ai/internal/registry"
 )
+
+const (
+	maxSample    = 8
+	maxExtGroups = 6
+	minCompact   = 8
+)
+
+var months = []string{
+	"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+}
+
+var noiseDirs = map[string]struct{}{
+	"node_modules": {},
+	".git":         {},
+	"target":       {},
+	"dist":         {},
+	"vendor":       {},
+	"__pycache__":  {},
+	".next":        {},
+	"build":        {},
+	"coverage":     {},
+	".cache":       {},
+}
 
 func init() {
 	registry.Register(&Module{})
@@ -17,56 +41,29 @@ type Module struct{}
 
 func (m *Module) Name() string { return "ls" }
 
-func (m *Module) Rewrite(args []string) ([]string, bool) {
-	// No rewrite needed — we filter output instead
-	return nil, false
+func (m *Module) ExtraEnv(_ []string) []string {
+	return []string{"LC_ALL=C"}
 }
 
-func (m *Module) FilterOutput(_ []string, output string) string {
-	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
-	if len(lines) == 0 {
-		return output
-	}
-
-	var dirs, files []string
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if strings.HasSuffix(line, "/") {
-			dirs = append(dirs, line)
-		} else {
-			files = append(files, line)
+func (m *Module) Rewrite(args []string) ([]string, bool) {
+	for _, a := range args {
+		if a == "--help" {
+			return nil, false
 		}
 	}
-
-	var sb strings.Builder
-
-	if len(dirs) > 0 {
-		sb.WriteString(fmt.Sprintf("📁 %d dirs: %s\n", len(dirs), strings.Join(dirs, " ")))
+	out := buildArgs(args)
+	if sameArgs(out, args) {
+		return nil, false
 	}
-	if len(files) > 0 {
-		// Group files by extension
-		byExt := map[string][]string{}
-		for _, f := range files {
-			ext := extOf(f)
-			byExt[ext] = append(byExt[ext], f)
-		}
-		sb.WriteString(fmt.Sprintf("📄 %d files\n", len(files)))
-		for ext, group := range byExt {
-			if ext == "" {
-				ext = "no-ext"
-			}
-			sb.WriteString(fmt.Sprintf("  .%s(%d): %s\n", ext, len(group), strings.Join(group, " ")))
-		}
-	}
+	return out, true
+}
 
-	result := sb.String()
-	if len(result) >= len(output) {
-		return output
+func (m *Module) FilterOutput(args []string, output string) string {
+	showAll := wantsAll(args)
+	if isLongListing(output) {
+		return compactLong(output, showAll)
 	}
-	return result
+	return compactNames(output, showAll)
 }
 
 func (m *Module) TokensBefore(output string) int {
@@ -77,10 +74,330 @@ func (m *Module) TokensAfter(filtered string) int {
 	return registry.EstimateTokens(filtered)
 }
 
+func buildArgs(args []string) []string {
+	var flags, paths []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			flags = append(flags, a)
+		} else {
+			paths = append(paths, a)
+		}
+	}
+
+	lead := "-l"
+	if wantsAll(args) {
+		lead = "-la"
+	}
+	out := []string{lead}
+	for _, f := range flags {
+		if f == "--all" {
+			continue
+		}
+		if strings.HasPrefix(f, "--") {
+			out = append(out, f)
+			continue
+		}
+		stripped := strings.TrimLeft(f, "-")
+		var extra strings.Builder
+		for _, c := range stripped {
+			if c != 'l' && c != 'a' && c != 'h' {
+				extra.WriteRune(c)
+			}
+		}
+		if extra.Len() > 0 {
+			out = append(out, "-"+extra.String())
+		}
+	}
+	return append(out, paths...)
+}
+
+func sameArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func wantsAll(args []string) bool {
+	for _, a := range args {
+		if a == "--all" {
+			return true
+		}
+		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") && strings.ContainsRune(a, 'a') {
+			return true
+		}
+	}
+	return false
+}
+
+func isLongListing(output string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "total ") {
+			return true
+		}
+		if dateStart(line) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+type entry struct {
+	name string
+	dir  bool
+	size string
+}
+
+func compactLong(output string, showAll bool) string {
+	var dirs, files []entry
+	byExt := map[string]int{}
+	parsed := 0
+	sawContent := false
+
+	for _, line := range strings.Split(output, "\n") {
+		if line == "" || strings.HasPrefix(line, "total ") {
+			continue
+		}
+		sawContent = true
+		e, ok := parseLongLine(line)
+		if !ok {
+			continue
+		}
+		parsed++
+		if !showAll && isNoise(e.name) {
+			continue
+		}
+		if e.dir {
+			dirs = append(dirs, e)
+			continue
+		}
+		files = append(files, e)
+		byExt[extOf(e.name)]++
+	}
+
+	if parsed == 0 && sawContent {
+		return output
+	}
+	return render(dirs, files, byExt, output)
+}
+
+func compactNames(output string, showAll bool) string {
+	var dirs, files []entry
+	byExt := map[string]int{}
+
+	for _, line := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || name == "." || name == ".." {
+			continue
+		}
+		if !showAll && isNoise(strings.TrimSuffix(name, "/")) {
+			continue
+		}
+		if strings.HasSuffix(name, "/") {
+			dirs = append(dirs, entry{name: strings.TrimSuffix(name, "/"), dir: true})
+			continue
+		}
+		files = append(files, entry{name: name})
+		byExt[extOf(name)]++
+	}
+
+	return render(dirs, files, byExt, output)
+}
+
+func render(dirs, files []entry, byExt map[string]int, original string) string {
+	total := len(dirs) + len(files)
+	if total == 0 {
+		return original
+	}
+	if total < minCompact {
+		return original
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d dirs, %d files\n", len(dirs), len(files)))
+
+	if len(dirs) > 0 {
+		sb.WriteString("dirs: ")
+		n := len(dirs)
+		if n > maxSample {
+			n = maxSample
+		}
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				sb.WriteByte(' ')
+			}
+			sb.WriteString(dirs[i].name)
+			sb.WriteByte('/')
+		}
+		if len(dirs) > maxSample {
+			sb.WriteString(fmt.Sprintf(" ... +%d more", len(dirs)-maxSample))
+		}
+		sb.WriteByte('\n')
+	}
+
+	if len(files) > 0 {
+		type extGroup struct {
+			ext   string
+			count int
+		}
+		groups := make([]extGroup, 0, len(byExt))
+		for ext, n := range byExt {
+			groups = append(groups, extGroup{ext, n})
+		}
+		for i := 0; i < len(groups); i++ {
+			for j := i + 1; j < len(groups); j++ {
+				if groups[j].count > groups[i].count || (groups[j].count == groups[i].count && groups[j].ext < groups[i].ext) {
+					groups[i], groups[j] = groups[j], groups[i]
+				}
+			}
+		}
+
+		shown := 0
+		for _, g := range groups {
+			if shown >= maxExtGroups {
+				sb.WriteString(fmt.Sprintf("  +%d more ext\n", len(groups)-shown))
+				break
+			}
+			label := g.ext
+			if label == "" {
+				label = "no-ext"
+			} else {
+				label = "." + label
+			}
+			sb.WriteString(fmt.Sprintf("  %s(%d):", label, g.count))
+			written := 0
+			for _, f := range files {
+				if extOf(f.name) != g.ext {
+					continue
+				}
+				if written >= maxSample {
+					break
+				}
+				sb.WriteByte(' ')
+				sb.WriteString(f.name)
+				if f.size != "" {
+					sb.WriteByte(' ')
+					sb.WriteString(f.size)
+				}
+				written++
+			}
+			if g.count > maxSample {
+				sb.WriteString(fmt.Sprintf(" ... +%d more", g.count-maxSample))
+			}
+			sb.WriteByte('\n')
+			shown++
+		}
+	}
+
+	result := sb.String()
+	if len(result) >= len(original) {
+		return original
+	}
+	return result
+}
+
+func parseLongLine(line string) (entry, bool) {
+	start := dateStart(line)
+	if start < 0 {
+		return entry{}, false
+	}
+	nameStart := dateEnd(line, start)
+	if nameStart < 0 || nameStart >= len(line) {
+		return entry{}, false
+	}
+	name := line[nameStart:]
+	if name == "." || name == ".." {
+		return entry{}, false
+	}
+
+	before := strings.Fields(line[:start])
+	if len(before) < 1 {
+		return entry{}, false
+	}
+	perms := before[0]
+	if len(perms) < 10 {
+		return entry{}, false
+	}
+
+	var size uint64
+	for i := len(before) - 1; i >= 1; i-- {
+		n, err := strconv.ParseUint(before[i], 10, 64)
+		if err == nil {
+			size = n
+			break
+		}
+	}
+
+	return entry{
+		name: name,
+		dir:  perms[0] == 'd',
+		size: humanSize(size),
+	}, true
+}
+
+func dateStart(line string) int {
+	for _, m := range months {
+		needle := " " + m + " "
+		if i := strings.Index(line, needle); i >= 0 {
+			return i
+		}
+	}
+	return -1
+}
+
+func dateEnd(line string, monthIdx int) int {
+	rest := line[monthIdx+1:]
+	fields := strings.Fields(rest)
+	if len(fields) < 3 {
+		return -1
+	}
+	consumed := 0
+	for i := 0; i < 3; i++ {
+		idx := strings.Index(rest[consumed:], fields[i])
+		if idx < 0 {
+			return -1
+		}
+		consumed += idx + len(fields[i])
+	}
+	if monthIdx+1+consumed < len(line) && line[monthIdx+1+consumed] == ' ' {
+		consumed++
+	}
+	return monthIdx + 1 + consumed
+}
+
+func humanSize(n uint64) string {
+	switch {
+	case n >= 1048576:
+		return fmt.Sprintf("%.1fM", float64(n)/1048576)
+	case n >= 1024:
+		return fmt.Sprintf("%.1fK", float64(n)/1024)
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}
+
+func isNoise(name string) bool {
+	base := name
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		base = name[i+1:]
+	}
+	_, ok := noiseDirs[base]
+	return ok
+}
+
 func extOf(name string) string {
-	dot := strings.LastIndex(name, ".")
-	if dot < 0 || dot == len(name)-1 {
+	base := name
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		base = name[i+1:]
+	}
+	dot := strings.LastIndex(base, ".")
+	if dot <= 0 || dot == len(base)-1 {
 		return ""
 	}
-	return name[dot+1:]
+	return base[dot+1:]
 }

--- a/modules/ls/ls.go
+++ b/modules/ls/ls.go
@@ -22,7 +22,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 	return nil, false
 }
 
-func (m *Module) FilterOutput(output string) string {
+func (m *Module) FilterOutput(_ []string, output string) string {
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
 	if len(lines) == 0 {
 		return output

--- a/modules/ls/ls_test.go
+++ b/modules/ls/ls_test.go
@@ -1,0 +1,99 @@
+package ls
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRewriteInjectsLa(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite(nil)
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	if len(got) != 1 || got[0] != "-l" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestRewriteAlreadyLa(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"-la"})
+	if ok {
+		t.Fatal("ls -la must not rewrite")
+	}
+}
+
+func TestRewriteStripsDuplicateFlags(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"src"})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	if len(got) != 2 || got[0] != "-l" || got[1] != "src" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestFilterNamesCompact(t *testing.T) {
+	m := &Module{}
+	var sb strings.Builder
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&sb, "handler_%02d.go\n", i)
+	}
+	raw := sb.String()
+	out := m.FilterOutput(nil, raw)
+	if out == raw {
+		t.Fatal("expected compact listing")
+	}
+	if !strings.Contains(out, "40 files") {
+		t.Fatalf("got %q", out)
+	}
+	if strings.Count(out, "handler_") > 10 {
+		t.Fatalf("should sample names, got %q", out)
+	}
+}
+
+func TestFilterLongListing(t *testing.T) {
+	m := &Module{}
+	var sb strings.Builder
+	sb.WriteString("total 48\n")
+	sb.WriteString("drwxr-xr-x 2 user staff 64 Jan 1 12:00 .\n")
+	sb.WriteString("drwxr-xr-x 2 user staff 64 Jan 1 12:00 ..\n")
+	for i := 0; i < 20; i++ {
+		fmt.Fprintf(&sb, "-rw-r--r-- 1 user staff 1234 Jan 1 12:00 file_%02d.go\n", i)
+	}
+	sb.WriteString("drwxr-xr-x 2 user staff 64 Jan 1 12:00 src\n")
+	sb.WriteString("drwxr-xr-x 2 user staff 64 Jan 1 12:00 node_modules\n")
+	raw := sb.String()
+	out := m.FilterOutput([]string{"-l"}, raw)
+	if strings.Contains(out, "node_modules") {
+		t.Fatalf("noise dir leaked: %s", out)
+	}
+	if !strings.Contains(out, "src/") {
+		t.Fatalf("missing dir: %s", out)
+	}
+	if !strings.Contains(out, ".go") {
+		t.Fatalf("missing ext: %s", out)
+	}
+	if strings.Contains(out, "drwx") {
+		t.Fatalf("raw perms leaked: %s", out)
+	}
+}
+
+func TestFilterSmallUnchanged(t *testing.T) {
+	m := &Module{}
+	raw := "main.go\ngo.mod\n"
+	if got := m.FilterOutput(nil, raw); got != raw {
+		t.Fatalf("small listing must stay raw, got %q", got)
+	}
+}
+
+func TestExtraEnv(t *testing.T) {
+	m := &Module{}
+	got := m.ExtraEnv(nil)
+	if len(got) != 1 || got[0] != "LC_ALL=C" {
+		t.Fatalf("got %v", got)
+	}
+}

--- a/modules/mcpscan/mcpscan.go
+++ b/modules/mcpscan/mcpscan.go
@@ -247,7 +247,7 @@ func mcpHandshake(w io.Writer, r io.Reader) ([]string, error) {
 		Params: map[string]interface{}{
 			"protocolVersion": "2024-11-05",
 			"capabilities":    map[string]interface{}{},
-			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.3.3"},
+			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.4.0"},
 		},
 	}); err != nil {
 		return nil, err

--- a/modules/rg/rg.go
+++ b/modules/rg/rg.go
@@ -1,19 +1,9 @@
 // Module rg: filters `rg` (ripgrep) output for Claude Code.
-// Handles both heading format (default) and flat format (--no-heading / file:line:content).
 package rg
 
 import (
-	"fmt"
-	"strings"
-
+	"github.com/jmeiracorbal/gtk-ai/internal/matchgroup"
 	"github.com/jmeiracorbal/gtk-ai/internal/registry"
-)
-
-const (
-	maxTotalMatches   = 200
-	maxMatchesPerFile = 10
-	maxFiles          = 20
-	minLines          = 5
 )
 
 func init() {
@@ -29,68 +19,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 }
 
 func (m *Module) FilterOutput(_ []string, output string) string {
-	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
-
-	var nonempty []string
-	for _, l := range lines {
-		if strings.TrimSpace(l) != "" {
-			nonempty = append(nonempty, l)
-		}
-	}
-
-	if len(nonempty) < minLines {
-		return output
-	}
-
-	byFile := parseRgOutput(nonempty)
-
-	totalMatches := 0
-	for _, matches := range byFile.matches {
-		totalMatches += len(matches)
-	}
-
-	if totalMatches == 0 {
-		return output
-	}
-
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("🔍 %d matches in %d files\n\n", totalMatches, len(byFile.order)))
-
-	filesShown := 0
-	for _, file := range byFile.order {
-		if filesShown >= maxFiles {
-			remaining := len(byFile.order) - filesShown
-			sb.WriteString(fmt.Sprintf("... +%d more files\n", remaining))
-			break
-		}
-		matches := byFile.matches[file]
-		sb.WriteString(file)
-		sb.WriteString("\n")
-		limit := len(matches)
-		if limit > maxMatchesPerFile {
-			limit = maxMatchesPerFile
-		}
-		for _, l := range matches[:limit] {
-			sb.WriteString("  ")
-			sb.WriteString(l)
-			sb.WriteString("\n")
-		}
-		if len(matches) > maxMatchesPerFile {
-			sb.WriteString(fmt.Sprintf("  ... +%d more matches\n", len(matches)-maxMatchesPerFile))
-		}
-		sb.WriteString("\n")
-		filesShown++
-	}
-
-	if totalMatches > maxTotalMatches {
-		sb.WriteString(fmt.Sprintf("... [gtkai: %d total matches, output truncated]\n", totalMatches))
-	}
-
-	result := sb.String()
-	if len(result) >= len(output) {
-		return output
-	}
-	return result
+	return matchgroup.Format(output)
 }
 
 func (m *Module) TokensBefore(output string) int {
@@ -99,87 +28,4 @@ func (m *Module) TokensBefore(output string) int {
 
 func (m *Module) TokensAfter(filtered string) int {
 	return registry.EstimateTokens(filtered)
-}
-
-// fileMatches preserves insertion order.
-type fileMatches struct {
-	order   []string
-	matches map[string][]string
-}
-
-// isMatchLine reports whether a line is a rg match line in heading format.
-// Match lines start with one or more digits followed immediately by ':' or '-'
-// (e.g. "15:content" or "15-context"). File names that start with digits
-// (e.g. "123.go") do not match this pattern.
-func isMatchLine(l string) bool {
-	i := 0
-	for i < len(l) && l[i] >= '0' && l[i] <= '9' {
-		i++
-	}
-	if i == 0 || i >= len(l) {
-		return false
-	}
-	return l[i] == ':' || l[i] == '-'
-}
-
-// parseRgOutput handles both rg output formats:
-//
-// Heading format (rg default, with -n):
-//
-//	src/file.go
-//	15:    return fmt.Errorf("error")
-//
-// Flat format (--no-heading):
-//
-//	src/file.go:15:    return fmt.Errorf("error")
-//
-// Detection: if any non-empty line matches the match-line pattern (digits followed
-// by ':' or '-'), the output is in heading format. Otherwise flat.
-func parseRgOutput(lines []string) fileMatches {
-	result := fileMatches{matches: map[string][]string{}}
-
-	headingFormat := false
-	for _, l := range lines {
-		if isMatchLine(l) {
-			headingFormat = true
-			break
-		}
-	}
-
-	if headingFormat {
-		currentFile := ""
-		for _, l := range lines {
-			if isMatchLine(l) {
-				if currentFile != "" {
-					result.matches[currentFile] = append(result.matches[currentFile], l)
-				}
-			} else {
-				currentFile = l
-				if _, seen := result.matches[currentFile]; !seen {
-					result.order = append(result.order, currentFile)
-					result.matches[currentFile] = nil
-				}
-			}
-		}
-	} else {
-		// Flat format: file:line:content or file:content
-		for _, l := range lines {
-			file := flatFile(l)
-			if _, seen := result.matches[file]; !seen {
-				result.order = append(result.order, file)
-			}
-			result.matches[file] = append(result.matches[file], l)
-		}
-	}
-
-	return result
-}
-
-// flatFile extracts the filename from a flat rg line (file:line:content or file:content).
-func flatFile(line string) string {
-	parts := strings.SplitN(line, ":", 2)
-	if len(parts) > 0 {
-		return parts[0]
-	}
-	return ""
 }

--- a/modules/rg/rg.go
+++ b/modules/rg/rg.go
@@ -28,7 +28,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 	return nil, false
 }
 
-func (m *Module) FilterOutput(output string) string {
+func (m *Module) FilterOutput(_ []string, output string) string {
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
 
 	var nonempty []string

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
-  "description": "PostToolUse hook that applies rule-based filtering to Bash, grep, find, ls, git, Read, and MCP tool output before it reaches the agent.",
-  "version": "0.3.3",
+  "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
+  "version": "0.4.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,6 +1,18 @@
 {
-  "description": "gtk-ai PostToolUse hook: applies rule-based filtering to Bash, MCP, and Read output before it reaches the agent",
+  "description": "gtk-ai hooks: PreToolUse rewrites Bash commands to gtkai; PostToolUse filters Read, MCP, and unre-written Bash output",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/scripts/gtkai-pre-tool-use.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash|mcp__.*|Read",

--- a/plugin/scripts/gtkai-pre-tool-use.sh
+++ b/plugin/scripts/gtkai-pre-tool-use.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# gtkai PreToolUse hook for Claude Code.
+
+GTKAI=$(command -v gtkai 2>/dev/null)
+if [ -z "$GTKAI" ]; then
+  for candidate in "$HOME/.local/bin/gtkai" "/usr/local/bin/gtkai" "/opt/homebrew/bin/gtkai"; do
+    if [ -x "$candidate" ]; then
+      GTKAI="$candidate"
+      break
+    fi
+  done
+fi
+
+[ -z "$GTKAI" ] && exit 0
+exec "$GTKAI" hook-pre


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Registered Bash commands are rewritten in PreToolUse to `gtkai <cmd>`. The binary runs the real command, injects compact flags, filters stdout, records gain, and returns the child exit code.

## What landed

- `gtkai hook-pre` + plugin `PreToolUse` matcher `Bash`
- CLI proxy `gtkai <module> [args…]`
- Command detection (`/usr/bin/git`, `sudo`, `VAR=1`, `&&`/`||`/`;`, last-stage `grep`/`rg` pipelines)
- `never_worse` + ANSI strip
- `git status` → `--porcelain -b`, grouped by state
- `ls`: `-l` + `LC_ALL=C`; counts + samples; skips noise dirs
- `find`: groups by directory, cap 50
- `grep` / `rg`: shared grouping; grep injects `-nH`
- `git log`: pretty-format and `-10` unless the user passed format/`-n`
- `git diff`: strips headers, caps hunks

`PostToolUse` remains for `Read`, MCP, and Bash that was not rewritten.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a010d2-9511-771b-a0c6-f6999e0b718a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a010d2-9511-771b-a0c6-f6999e0b718a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

