### PR TITLE
feat: complete roadmap section 2 (0.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "gtk-ai",
       "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Two independent phases:
 
 Never collapse both phases into one. The plugin depends on the binary. The binary does not configure Claude Code.
 
-Target flow and remaining work: `ROADMAP.md`. `0.4.0` rewrites registered Bash commands in `PreToolUse` (`git status` → `gtkai git status`, same for `ls`/`find`/`grep`/`rg`). The proxy injects compact flags and filters stdout. `PostToolUse` still filters Read, MCP, and Bash commands that were not rewritten.
+Target flow and remaining work: `ROADMAP.md`. `0.5.0` completes §2: PreToolUse proxy for registered Bash commands; `PostToolUse` only for Read and MCP.
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gtk-ai
 
 ![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go&logoColor=white)
-![Version](https://img.shields.io/badge/version-0.4.0-blue?style=flat)
+![Version](https://img.shields.io/badge/version-0.5.0-blue?style=flat)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin%20compatible-blueviolet?style=flat)
 ![Build](https://img.shields.io/badge/build-passing-brightgreen?style=flat)
@@ -93,8 +93,10 @@ Each module handles one command. All built-in modules ship with the binary.
 |---|---|---|
 | `find` | `find` | Groups paths by directory, caps shown files, extension summary |
 | `ls` | `ls` | Injects `-l` + `LC_ALL=C` (and `-a` only if the user asked); compact to counts and samples; skips noise dirs |
-| `git` | `git diff/log/status/branch` | `status` injects `--porcelain -b`; `log` injects pretty-format and `-10`; `diff` strips headers and caps hunks |
+| `git` | `git` | status/log/diff/branch/show; write subcommands compact on exit 0; push/pull/fetch inject `-q` |
 | `grep` / `rg` | `grep`, `rg` | Shared grouping by file with per-file and total caps; `grep` injects `-nH` |
+| `cat` / `head` / `tail` | same | Reuses `read.FilterContent` on single-file output |
+| `tree` | `tree` | Entry count + capped listing |
 | `gain` | — | SQLite analytics: recorded on each proxy run |
 
 ## Adding a module
@@ -117,7 +119,7 @@ func (m *Module) Name() string { return "mycommand" }
 
 func (m *Module) Rewrite(args []string) ([]string, bool) { return nil, false }
 
-func (m *Module) FilterOutput(args []string, output string) string { return output }
+func (m *Module) FilterOutput(args []string, output string, exitCode int) string { return output }
 
 func (m *Module) TokensBefore(output string) int { return registry.EstimateTokens(output) }
 
@@ -146,8 +148,8 @@ To identify which tools to exempt, check the tool names returned by your MCP ser
 
 ```text
 gtkai hook-pre      PreToolUse handler — rewrites Bash commands to gtkai
-gtkai hook-post     PostToolUse handler — reads stdin JSON, writes filtered output
-gtkai git status    Proxy: run a registered command through gtkai (`ls`, `find`, `grep`, `rg`, `git`)
+gtkai hook-post     PostToolUse handler — filters Read and MCP only
+gtkai git status    Proxy: run a registered command through gtkai
 gtkai mcp-scan      List MCP server tools, suggest passthrough prefixes
 gtkai gain          Token savings analytics
 gtkai version       Print version
@@ -170,6 +172,8 @@ gtk-ai/
 │   ├── ls/                 # ls output filter
 │   ├── git/                # git subcommand filters
 │   ├── grep/               # grep output filter
+│   ├── readcmd/            # cat/head/tail via read.FilterContent
+│   ├── tree/               # tree output filter
 │   └── gain/               # SQLite token savings analytics
 └── plugin/
     ├── hooks/              # Claude plugin hook registration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap: gtk-ai vs rtk 0.42.4
 
-Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.4.0`.
+Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.5.0`.
 
 **Product decision (2026-08-17):** gtk follows the same path as rtk. It rewrites the command **before** execution (`PreToolUse` → `git status` becomes `gtkai git status`). gtkai runs the real binary, injects flags, and filters the output. Post-filtering remains only for Claude Code native tools that do not go through Bash (`Read`, MCP, `Grep`, `Glob`).
 
@@ -77,18 +77,18 @@ With the proxy, these modules can inject flags. That is what they cannot do toda
 | `git status` | Expects porcelain. Claude runs the long format; the parser never matches. | Covered in the primary phase. |
 | `git diff` | Done in `0.4.0`: strip `index`/`+++`/`---`, cap per hunk. | — |
 | `git log` | Done in `0.4.0`: inject `%h %s (%ar) <%an>` and `-10`; honor `--pretty`/`--oneline`/`-n`. | — |
-| `git branch` | Partial. | Filter remotes; cap. |
+| `git branch` | Done in `0.5.0`: cap local branches; skip remote-tracking `->`. | — |
 | `grep` | Done in `0.4.0`: same grouping as `rg`; injects `-nH`. | — |
 | `rg` | Grouping shared with `grep`. Pipelines rewrite the last stage. | — |
 | `find` | Done in `0.4.0`: group by directory, cap 50, small outputs unchanged. | — |
-| `Read` | Only `//` and `#` lines. | `/* */` blocks, more extensions. No “signatures only” mode (rtk aggressive: unsafe). |
-| `gain` | SQLite is ready; the hook never records. | Wired in the proxy runner (phase 1). |
+| `Read` | Done in `0.5.0`: `/* */` block comments; `.css`/`.vue`/`.svelte`. | Native `Grep`/`Glob` still PostToolUse |
+| `gain` | Wired in the proxy runner (phase 1). | Per-filter `id` when §4 lands |
 
 Add in the same block, because they are the same Bash path rtk rewrites to `read`:
 
-- `git show`, `git add`/`commit`/`push`/`pull`/`fetch`/`stash` (confirmation, no progress).
-- `cat` / `head` / `tail` → `gtkai read` (reuses `read.FilterContent`).
-- `tree`.
+- `git show`, `git add`/`commit`/`push`/`pull`/`fetch`/`stash` — **done in 0.5.0** (compact on exit 0; `-q` on push/pull/fetch).
+- `cat` / `head` / `tail` → proxy modules reusing `read.FilterContent` — **done in 0.5.0**.
+- `tree` — **done in 0.5.0** (entry count + capped listing).
 
 Native tools (stay on `PostToolUse`; rtk cannot do this):
 
@@ -207,14 +207,14 @@ Done when: native `gtkai/gtkai-*` filters use the same registry; install/uninsta
 
 ## Current vs target
 
-| | gtk-ai 0.4.0 | Remaining |
+| | gtk-ai 0.5.0 | Remaining |
 |---|---|---|
-| Bash | `PreToolUse` rewrites registered commands to `gtkai …`; the binary runs and filters | Drop Bash `PostToolUse` once coverage is trusted |
+| Bash | `PreToolUse` rewrites registered commands to `gtkai …`; the binary runs and filters | Bash removed from `PostToolUse` (0.5.0) |
 | Filter identity | Flat `registry.Get("ls")` | Namespaced `author/gtkai-<command>`; active = most recent install |
 | `Rewrite()` | Injects flags for `git status`, `git log`, `ls`, `grep` | Runners (`go test -json`); third-party filters via `filter install` |
 | `Read` / MCP | `PostToolUse` | `/* */` on Read; native `Grep`/`Glob` |
 | `gain` | Every proxy execution | Per-filter attribution by `id` |
-| Commands | find, ls, git (status/log/diff/branch), grep, rg, Read, MCP | §2 remainder, then runners, then filter plugin CLI |
+| Commands | find, ls, git (incl. show/write/stash), grep, rg, cat/head/tail, tree, Read, MCP | Runners; filter plugin registry (§4) |
 
 Filtering stays heuristic. No semantic compression.
 
@@ -235,7 +235,7 @@ Filtering stays heuristic. No semantic compression.
 ## PR order
 
 1. PreToolUse proxy + end-to-end `git status` (section 1) — **done in 0.4.0**.
-2. Corrections to current modules + `cat`/`head`/`tail`/`tree` + remaining git (section 2).
+2. Corrections to current modules + `cat`/`head`/`tail`/`tree` + remaining git (section 2) — **done in 0.5.0**.
 3. Runners (section 3).
 4. Filter plugin registry + install/uninstall/list + migrate natives to `gtkai/gtkai-*` (section 4).
 5. Ecosystem commands as third-party filters according to `gain` (section 3 ecosystem).

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -16,10 +16,12 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/readcmd"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
 
-const version = "0.4.0"
+const version = "0.5.0"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s

--- a/internal/hook/post_tool_use.go
+++ b/internal/hook/post_tool_use.go
@@ -157,7 +157,7 @@ func filterBashOutput(command, output string) (string, bool) {
 	}
 
 	stripped := text.StripANSI(output)
-	filtered := mod.FilterOutput(fields[1:], stripped)
+	filtered := mod.FilterOutput(fields[1:], stripped, -1)
 	shown := registry.NeverWorse(output, filtered)
 	return shown, shown != output
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -47,7 +47,7 @@ func Run(name string, args []string) int {
 	elapsed := time.Since(start)
 
 	stripped := text.StripANSI(execOut)
-	filtered := mod.FilterOutput(execArgs, stripped)
+	filtered := mod.FilterOutput(execArgs, stripped, execCode)
 	shown := registry.NeverWorse(rawOut, filtered)
 
 	if _, werr := os.Stdout.WriteString(shown); werr != nil {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -19,7 +19,8 @@ type Module interface {
 
 	// FilterOutput applies heuristic pruning to command output before it reaches the agent.
 	// args are the words after the module name (e.g. ["status", "-sb"] for git).
-	FilterOutput(args []string, output string) string
+	// exitCode is the child exit status; pass -1 when unknown (PostToolUse).
+	FilterOutput(args []string, output string, exitCode int) string
 
 	// TokensBefore estimates tokens in the original output.
 	TokensBefore(output string) int

--- a/internal/shell/rewrite_test.go
+++ b/internal/shell/rewrite_test.go
@@ -7,7 +7,9 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/readcmd"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
 
 func TestRewriteGitStatus(t *testing.T) {
@@ -91,6 +93,9 @@ func TestRewriteRegisteredModules(t *testing.T) {
 		{"find . -name '*.go'", "gtkai find . -name '*.go'"},
 		{"grep -n foo src", "gtkai grep -n foo src"},
 		{"rg Error src", "gtkai rg Error src"},
+		{"cat main.go", "gtkai cat main.go"},
+		{"head -n 10 main.go", "gtkai head -n 10 main.go"},
+		{"tree -L 2", "gtkai tree -L 2"},
 	}
 	for _, tc := range cases {
 		got, ok := Rewrite(tc.in, "gtkai")

--- a/modules/find/find.go
+++ b/modules/find/find.go
@@ -27,7 +27,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 	return nil, false
 }
 
-func (m *Module) FilterOutput(_ []string, output string) string {
+func (m *Module) FilterOutput(_ []string, output string, _ int) string {
 	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
 	var paths []string
 	for _, l := range lines {

--- a/modules/find/find_test.go
+++ b/modules/find/find_test.go
@@ -14,7 +14,7 @@ func TestFilterGroupsByDirectory(t *testing.T) {
 		fmt.Fprintf(&sb, "./src/module_%02d/util.go\n", i)
 	}
 	raw := sb.String()
-	out := m.FilterOutput(nil, raw)
+	out := m.FilterOutput(nil, raw, 0)
 	if out == raw {
 		t.Fatal("expected grouped output")
 	}
@@ -32,14 +32,14 @@ func TestFilterGroupsByDirectory(t *testing.T) {
 func TestFilterSmallUnchanged(t *testing.T) {
 	m := &Module{}
 	raw := "./main.go\n./go.mod\n"
-	if got := m.FilterOutput(nil, raw); got != raw {
+	if got := m.FilterOutput(nil, raw, 0); got != raw {
 		t.Fatalf("got %q", got)
 	}
 }
 
 func TestFilterEmptyUnchanged(t *testing.T) {
 	m := &Module{}
-	if got := m.FilterOutput(nil, ""); got != "" {
+	if got := m.FilterOutput(nil, "", 0); got != "" {
 		t.Fatalf("got %q", got)
 	}
 }

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -17,6 +17,8 @@ const (
 	maxLogUserFmt   = 50
 	maxLogLineWidth = 80
 	maxStatusLines  = 100
+	maxBranchList   = 15
+	maxStashEntries = 20
 	prettyLogFmt    = "%h %s (%ar) <%an>"
 )
 
@@ -42,9 +44,37 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 		return out, true
 	case "log":
 		return rewriteLog(globals, rest)
+	case "push", "pull", "fetch":
+		return rewriteQuiet(globals, sub, rest)
 	default:
 		return nil, false
 	}
+}
+
+func rewriteQuiet(globals []string, sub string, rest []string) ([]string, bool) {
+	if hasVerboseFlag(rest) {
+		return nil, false
+	}
+	out := append(append([]string{}, globals...), sub, "-q")
+	out = append(out, rest...)
+	return out, true
+}
+
+func hasVerboseFlag(args []string) bool {
+	for _, a := range args {
+		switch a {
+		case "-v", "-vv", "--verbose", "--progress":
+			return true
+		}
+		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") {
+			for _, c := range a[1:] {
+				if c == 'v' {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func rewriteLog(globals, rest []string) ([]string, bool) {
@@ -68,7 +98,7 @@ func rewriteLog(globals, rest []string) ([]string, bool) {
 	return out, true
 }
 
-func (m *Module) FilterOutput(args []string, output string) string {
+func (m *Module) FilterOutput(args []string, output string, exitCode int) string {
 	_, sub, rest, ok := splitGitArgs(args)
 	if !ok {
 		return output
@@ -82,6 +112,12 @@ func (m *Module) FilterOutput(args []string, output string) string {
 		return filterStatus(output)
 	case "branch":
 		return filterBranch(output)
+	case "show":
+		return filterShow(output)
+	case "add", "commit", "push", "pull", "fetch":
+		return filterWrite(sub, output, exitCode)
+	case "stash":
+		return filterStash(rest, output, exitCode)
 	default:
 		return output
 	}
@@ -468,8 +504,107 @@ func filterBranch(output string) string {
 		sb.WriteString(fmt.Sprintf("current: %s\n", current))
 	}
 	if len(branches) > 0 {
-		sb.WriteString(fmt.Sprintf("local (%d): %s\n", len(branches), strings.Join(branches, ", ")))
+		n := len(branches)
+		shown := branches
+		if n > maxBranchList {
+			shown = branches[:maxBranchList]
+			sb.WriteString(fmt.Sprintf("local (%d): %s ... +%d more\n", n, strings.Join(shown, ", "), n-maxBranchList))
+		} else {
+			sb.WriteString(fmt.Sprintf("local (%d): %s\n", n, strings.Join(shown, ", ")))
+		}
 	}
+	result := sb.String()
+	if result == "" {
+		return output
+	}
+	return result
+}
+
+func filterShow(output string) string {
+	if strings.Contains(output, "diff --git") || strings.Contains(output, "@@") {
+		return filterDiff(output)
+	}
+	return capLines(output, maxDiffLines)
+}
+
+func filterWrite(sub, output string, exitCode int) string {
+	if exitCode != 0 {
+		return output
+	}
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return "ok\n"
+	}
+	switch sub {
+	case "add":
+		return "ok\n"
+	case "commit":
+		for _, line := range strings.Split(output, "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "[") {
+				continue
+			}
+			end := strings.Index(line, "]")
+			if end <= 1 {
+				continue
+			}
+			inner := line[1:end]
+			fields := strings.Fields(inner)
+			if len(fields) >= 2 {
+				return fmt.Sprintf("ok %s\n", fields[1])
+			}
+		}
+		return "ok\n"
+	case "push", "fetch":
+		if len(trimmed) <= 80 {
+			return trimmed + "\n"
+		}
+		return "ok\n"
+	case "pull":
+		for _, line := range strings.Split(output, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.Contains(line, "file changed") || strings.Contains(line, "files changed") {
+				return "ok " + line + "\n"
+			}
+		}
+		return "ok\n"
+	default:
+		return output
+	}
+}
+
+func filterStash(args []string, output string, exitCode int) string {
+	if len(args) == 0 {
+		return output
+	}
+	switch args[0] {
+	case "list":
+		return filterStashList(output)
+	case "push", "pop", "apply", "drop", "clear":
+		return filterWrite("stash", output, exitCode)
+	default:
+		return output
+	}
+}
+
+func filterStashList(output string) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	var entries []string
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			entries = append(entries, l)
+		}
+	}
+	if len(entries) <= maxStashEntries {
+		return output
+	}
+	var sb strings.Builder
+	for _, e := range entries[:maxStashEntries] {
+		sb.WriteString(e)
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(fmt.Sprintf("... +%d more\n", len(entries)-maxStashEntries))
 	return sb.String()
 }
 

--- a/modules/git/write_test.go
+++ b/modules/git/write_test.go
@@ -1,0 +1,71 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilterWriteCommitSuccess(t *testing.T) {
+	raw := "[main abc1234] feat: thing\n 1 file changed, 2 insertions(+)\n"
+	out := filterWrite("commit", raw, 0)
+	if out != "ok abc1234\n" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestFilterWriteCommitFailurePassthrough(t *testing.T) {
+	raw := "nothing to commit, working tree clean\n"
+	out := filterWrite("commit", raw, 1)
+	if out != raw {
+		t.Fatalf("failed commit must pass through, got %q", out)
+	}
+}
+
+func TestFilterWriteAddSuccess(t *testing.T) {
+	out := filterWrite("add", "", 0)
+	if out != "ok\n" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestFilterStashListCap(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 30; i++ {
+		sb.WriteString("stash@{0}: WIP on main\n")
+	}
+	out := filterStashList(sb.String())
+	if !strings.Contains(out, "+10 more") {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestFilterBranchCap(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("* main\n")
+	for i := 0; i < 25; i++ {
+		sb.WriteString("  branch\n")
+	}
+	out := filterBranch(sb.String())
+	if !strings.Contains(out, "+10 more") {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestRewritePushQuiet(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"push"})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	if len(got) != 2 || got[0] != "push" || got[1] != "-q" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestRewritePushVerboseSkipped(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"push", "-v"})
+	if ok {
+		t.Fatal("verbose push must not inject -q")
+	}
+}

--- a/modules/grep/grep.go
+++ b/modules/grep/grep.go
@@ -39,7 +39,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 	return append(extra, args...), true
 }
 
-func (m *Module) FilterOutput(_ []string, output string) string {
+func (m *Module) FilterOutput(_ []string, output string, _ int) string {
 	return matchgroup.Format(output)
 }
 

--- a/modules/grep/grep_test.go
+++ b/modules/grep/grep_test.go
@@ -42,7 +42,7 @@ func TestFilterGroupsLikeRg(t *testing.T) {
 		}
 	}
 	raw := sb.String()
-	out := m.FilterOutput(nil, raw)
+	out := m.FilterOutput(nil, raw, 0)
 	if out == raw {
 		t.Fatal("expected grouped output")
 	}

--- a/modules/ls/ls.go
+++ b/modules/ls/ls.go
@@ -58,7 +58,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 	return out, true
 }
 
-func (m *Module) FilterOutput(args []string, output string) string {
+func (m *Module) FilterOutput(args []string, output string, _ int) string {
 	showAll := wantsAll(args)
 	if isLongListing(output) {
 		return compactLong(output, showAll)

--- a/modules/ls/ls_test.go
+++ b/modules/ls/ls_test.go
@@ -43,7 +43,7 @@ func TestFilterNamesCompact(t *testing.T) {
 		fmt.Fprintf(&sb, "handler_%02d.go\n", i)
 	}
 	raw := sb.String()
-	out := m.FilterOutput(nil, raw)
+	out := m.FilterOutput(nil, raw, 0)
 	if out == raw {
 		t.Fatal("expected compact listing")
 	}
@@ -67,7 +67,7 @@ func TestFilterLongListing(t *testing.T) {
 	sb.WriteString("drwxr-xr-x 2 user staff 64 Jan 1 12:00 src\n")
 	sb.WriteString("drwxr-xr-x 2 user staff 64 Jan 1 12:00 node_modules\n")
 	raw := sb.String()
-	out := m.FilterOutput([]string{"-l"}, raw)
+	out := m.FilterOutput([]string{"-l"}, raw, 0)
 	if strings.Contains(out, "node_modules") {
 		t.Fatalf("noise dir leaked: %s", out)
 	}
@@ -85,7 +85,7 @@ func TestFilterLongListing(t *testing.T) {
 func TestFilterSmallUnchanged(t *testing.T) {
 	m := &Module{}
 	raw := "main.go\ngo.mod\n"
-	if got := m.FilterOutput(nil, raw); got != raw {
+	if got := m.FilterOutput(nil, raw, 0); got != raw {
 		t.Fatalf("small listing must stay raw, got %q", got)
 	}
 }

--- a/modules/mcpscan/mcpscan.go
+++ b/modules/mcpscan/mcpscan.go
@@ -247,7 +247,7 @@ func mcpHandshake(w io.Writer, r io.Reader) ([]string, error) {
 		Params: map[string]interface{}{
 			"protocolVersion": "2024-11-05",
 			"capabilities":    map[string]interface{}{},
-			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.4.0"},
+			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.5.0"},
 		},
 	}); err != nil {
 		return nil, err

--- a/modules/read/read.go
+++ b/modules/read/read.go
@@ -28,6 +28,9 @@ func FilterContent(path, content string) (string, bool) {
 	lang := detectLang(path)
 	hasPrefix := detectLinePrefix(lines)
 
+	if lang == langSlash {
+		lines = stripBlockComments(lines, hasPrefix)
+	}
 	lines = stripCommentLines(lines, lang, hasPrefix)
 	lines = collapseBlankLines(lines, hasPrefix)
 
@@ -60,12 +63,12 @@ const (
 func detectLang(path string) language {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
-	case ".go", ".rs", ".js", ".mjs", ".cjs", ".ts", ".tsx", ".c", ".h", ".cpp", ".cc", ".java":
+	case ".go", ".rs", ".js", ".mjs", ".cjs", ".ts", ".tsx", ".c", ".h", ".cpp", ".cc", ".java", ".css", ".scss", ".vue", ".svelte":
 		return langSlash
 	case ".py", ".pyw", ".sh", ".bash", ".zsh", ".rb":
 		return langHash
 	case ".json", ".jsonc", ".yaml", ".yml", ".toml", ".md", ".markdown",
-		".txt", ".html", ".css", ".sql", ".lock", ".env":
+		".txt", ".html", ".sql", ".lock", ".env":
 		return langData
 	default:
 		return langUnknown
@@ -175,6 +178,47 @@ func stripCommentLines(lines []string, lang language, hasPrefix bool) []string {
 		}
 	}
 	return result
+}
+
+func stripBlockComments(lines []string, hasPrefix bool) []string {
+	inBlock := false
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		content := line
+		prefix := ""
+		if hasPrefix {
+			content = contentOf(line)
+			prefix = line[:len(line)-len(content)]
+		}
+		var kept strings.Builder
+		i := 0
+		for i < len(content) {
+			if inBlock {
+				end := strings.Index(content[i:], "*/")
+				if end < 0 {
+					i = len(content)
+					break
+				}
+				i += end + 2
+				inBlock = false
+				continue
+			}
+			start := strings.Index(content[i:], "/*")
+			if start < 0 {
+				kept.WriteString(content[i:])
+				break
+			}
+			kept.WriteString(content[i : i+start])
+			i += start + 2
+			inBlock = true
+		}
+		if kept.Len() > 0 {
+			out = append(out, prefix+kept.String())
+		} else if !inBlock && strings.TrimSpace(content) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
 }
 
 func collapseBlankLines(lines []string, hasPrefix bool) []string {

--- a/modules/read/read_test.go
+++ b/modules/read/read_test.go
@@ -1,0 +1,28 @@
+package read
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilterBlockComments(t *testing.T) {
+	raw := "package main\n/* block\n * line\n */\nvar x = 1\n"
+	filtered, changed := FilterContent("main.go", raw)
+	if !changed {
+		t.Fatal("expected block comment removal")
+	}
+	if strings.Contains(filtered, "block") {
+		t.Fatalf("block leaked: %q", filtered)
+	}
+	if !strings.Contains(filtered, "var x = 1") {
+		t.Fatalf("code missing: %q", filtered)
+	}
+}
+
+func TestFilterLineComments(t *testing.T) {
+	raw := "package main\n// comment\nvar x = 1\n"
+	filtered, changed := FilterContent("main.go", raw)
+	if !changed || strings.Contains(filtered, "// comment") {
+		t.Fatalf("got %q", filtered)
+	}
+}

--- a/modules/readcmd/readcmd.go
+++ b/modules/readcmd/readcmd.go
@@ -1,0 +1,70 @@
+// Package readcmd proxies cat/head/tail and filters with read.FilterContent.
+package readcmd
+
+import (
+	"strings"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+	readmod "github.com/jmeiracorbal/gtk-ai/modules/read"
+)
+
+func init() {
+	registry.Register(&Module{name: "cat"})
+	registry.Register(&Module{name: "head"})
+	registry.Register(&Module{name: "tail"})
+}
+
+type Module struct {
+	name string
+}
+
+func (m *Module) Name() string { return m.name }
+
+func (m *Module) Rewrite(_ []string) ([]string, bool) {
+	return nil, false
+}
+
+func (m *Module) FilterOutput(args []string, output string, _ int) string {
+	if strings.TrimSpace(output) == "" {
+		return output
+	}
+	path := filePath(args)
+	if path == "" {
+		return output
+	}
+	filtered, changed := readmod.FilterContent(path, output)
+	if !changed {
+		return output
+	}
+	return registry.NeverWorse(output, filtered)
+}
+
+func (m *Module) TokensBefore(output string) int {
+	return registry.EstimateTokens(output)
+}
+
+func (m *Module) TokensAfter(filtered string) int {
+	return registry.EstimateTokens(filtered)
+}
+
+func filePath(args []string) string {
+	var paths []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			paths = append(paths, args[i+1:]...)
+			break
+		}
+		if strings.HasPrefix(a, "-") {
+			if a == "-n" || a == "-c" {
+				i++
+			}
+			continue
+		}
+		paths = append(paths, a)
+	}
+	if len(paths) != 1 {
+		return ""
+	}
+	return paths[0]
+}

--- a/modules/readcmd/readcmd_test.go
+++ b/modules/readcmd/readcmd_test.go
@@ -1,0 +1,32 @@
+package readcmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilterSingleFile(t *testing.T) {
+	m := &Module{name: "cat"}
+	raw := strings.Repeat("// comment\nvar x = 1\n", 50)
+	out := m.FilterOutput([]string{"main.go"}, raw, 0)
+	if out == raw {
+		t.Fatal("expected comment strip")
+	}
+	if strings.Contains(out, "// comment") {
+		t.Fatalf("comments remain: %s", out)
+	}
+}
+
+func TestFilterMultipleFilesPassthrough(t *testing.T) {
+	m := &Module{name: "cat"}
+	raw := "a\nb\n"
+	if got := m.FilterOutput([]string{"a.go", "b.go"}, raw, 0); got != raw {
+		t.Fatalf("multi-file must pass through, got %q", got)
+	}
+}
+
+func TestFilePathSkipsFlags(t *testing.T) {
+	if got := filePath([]string{"-n", "10", "src/main.go"}); got != "src/main.go" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/modules/rg/rg.go
+++ b/modules/rg/rg.go
@@ -18,7 +18,7 @@ func (m *Module) Rewrite(args []string) ([]string, bool) {
 	return nil, false
 }
 
-func (m *Module) FilterOutput(_ []string, output string) string {
+func (m *Module) FilterOutput(_ []string, output string, _ int) string {
 	return matchgroup.Format(output)
 }
 

--- a/modules/tree/tree.go
+++ b/modules/tree/tree.go
@@ -1,0 +1,79 @@
+// Package tree filters `tree` output for Claude Code.
+package tree
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+const (
+	minCompact = 12
+	maxLines   = 40
+)
+
+func init() {
+	registry.Register(&Module{})
+}
+
+type Module struct{}
+
+func (m *Module) Name() string { return "tree" }
+
+func (m *Module) Rewrite(_ []string) ([]string, bool) {
+	return nil, false
+}
+
+func (m *Module) FilterOutput(_ []string, output string, _ int) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	var entries []string
+	for _, l := range lines {
+		l = strings.TrimRight(l, "\r")
+		if l == "" || strings.HasPrefix(l, "#") {
+			continue
+		}
+		entries = append(entries, l)
+	}
+	if len(entries) < minCompact {
+		return output
+	}
+
+	dirs, files := 0, 0
+	for _, e := range entries {
+		trimmed := strings.TrimSpace(e)
+		if strings.HasSuffix(trimmed, "/") {
+			dirs++
+		} else {
+			files++
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("tree: %d entries (%d dirs, %d files)\n\n", len(entries), dirs, files))
+	limit := len(entries)
+	if limit > maxLines {
+		limit = maxLines
+	}
+	for _, e := range entries[:limit] {
+		sb.WriteString(e)
+		sb.WriteByte('\n')
+	}
+	if len(entries) > maxLines {
+		sb.WriteString(fmt.Sprintf("... +%d more\n", len(entries)-maxLines))
+	}
+
+	result := sb.String()
+	if len(result) >= len(output) {
+		return output
+	}
+	return result
+}
+
+func (m *Module) TokensBefore(output string) int {
+	return registry.EstimateTokens(output)
+}
+
+func (m *Module) TokensAfter(filtered string) int {
+	return registry.EstimateTokens(filtered)
+}

--- a/modules/tree/tree_test.go
+++ b/modules/tree/tree_test.go
@@ -1,0 +1,31 @@
+package tree
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFilterLargeTree(t *testing.T) {
+	m := &Module{}
+	var sb strings.Builder
+	for i := 0; i < 50; i++ {
+		fmt.Fprintf(&sb, "    |-- file_%02d.go\n", i)
+	}
+	raw := sb.String()
+	out := m.FilterOutput(nil, raw, 0)
+	if out == raw {
+		t.Fatal("expected compact tree")
+	}
+	if !strings.Contains(out, "50 entries") {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestFilterSmallUnchanged(t *testing.T) {
+	m := &Module{}
+	raw := ".\n`-- main.go\n"
+	if got := m.FilterOutput(nil, raw, 0); got != raw {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "gtk-ai hooks: PreToolUse rewrites Bash commands to gtkai; PostToolUse filters Read, MCP, and unre-written Bash output",
+  "description": "gtk-ai hooks: PreToolUse rewrites Bash commands to gtkai; PostToolUse filters Read and MCP",
   "hooks": {
     "PreToolUse": [
       {
@@ -15,7 +15,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|mcp__.*|Read",
+        "matcher": "mcp__.*|Read",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completes roadmap §2 on top of `0.4.0`.

## Changes

- **git**: `show` uses diff compaction; `add`/`commit`/`push`/`pull`/`fetch`/`stash` compact stdout only on exit 0; push/pull/fetch inject `-q`; branch list capped
- **cat / head / tail**: new `readcmd` module reusing `read.FilterContent` (single-file only)
- **tree**: entry count + capped listing
- **Read**: strip `/* */` blocks; `.css`, `.vue`, `.svelte`
- **FilterOutput** now receives `exitCode` (`-1` when unknown in PostToolUse)
- **Plugin**: Bash removed from `PostToolUse` matcher (Read + MCP only)
- Version **0.5.0**

## Checks

- `go test ./...` green
- Commit author: Jose Meira

## Next (roadmap §3)

Runners: `go test -json`, cargo, pytest, npm, docker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a010d2-9511-771b-a0c6-f6999e0b718a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a010d2-9511-771b-a0c6-f6999e0b718a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

