### PR TITLE
feat: add go test runner with -json rewrite and output filter (0.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "gtk-ai",
       "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Two independent phases:
 
 Never collapse both phases into one. The plugin depends on the binary. The binary does not configure Claude Code.
 
-Target flow and remaining work: `ROADMAP.md`. `0.5.0` completes §2: PreToolUse proxy for registered Bash commands; `PostToolUse` only for Read and MCP.
+Target flow and remaining work: `ROADMAP.md`. `0.6.0` adds the `go test` runner (§3).
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gtk-ai
 
 ![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go&logoColor=white)
-![Version](https://img.shields.io/badge/version-0.5.0-blue?style=flat)
+![Version](https://img.shields.io/badge/version-0.6.0-blue?style=flat)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin%20compatible-blueviolet?style=flat)
 ![Build](https://img.shields.io/badge/build-passing-brightgreen?style=flat)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap: gtk-ai vs rtk 0.42.4
 
-Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.5.0`.
+Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.6.0`.
 
 **Product decision (2026-08-17):** gtk follows the same path as rtk. It rewrites the command **before** execution (`PreToolUse` → `git status` becomes `gtkai git status`). gtkai runs the real binary, injects flags, and filters the output. Post-filtering remains only for Claude Code native tools that do not go through Bash (`Read`, MCP, `Grep`, `Glob`).
 
@@ -107,7 +107,7 @@ Only after the proxy and the corrections. Here rewrite does inject flags (`go te
 
 | Module | Commands | Rewrite | Filter |
 |---|---|---|---|
-| `gotest` | `go test`, `go build`, `go vet` | `go test -json` unless `-bench` or `-json` is already present | `ok` packages → count; full `FAIL` |
+| `gotest` | `go test`, `go build`, `go vet` | `go test -json` unless `-bench` or `-json` is already present | `ok` packages → count; full `FAIL` — **done in 0.6.0** |
 | `cargo` | `test`, `build`, `clippy`, `check` | by subcommand | errors/failures; collapse `Compiling` |
 | `pytest` | `pytest`, `python -m pytest` | — | failures + short traceback |
 | `npmtest` | `npm test`, `pnpm test`, `npx vitest`/`jest` | — | failures; strip ANSI |
@@ -207,14 +207,14 @@ Done when: native `gtkai/gtkai-*` filters use the same registry; install/uninsta
 
 ## Current vs target
 
-| | gtk-ai 0.5.0 | Remaining |
+| | gtk-ai 0.6.0 | Remaining |
 |---|---|---|
 | Bash | `PreToolUse` rewrites registered commands to `gtkai …`; the binary runs and filters | Bash removed from `PostToolUse` (0.5.0) |
 | Filter identity | Flat `registry.Get("ls")` | Namespaced `author/gtkai-<command>`; active = most recent install |
-| `Rewrite()` | Injects flags for `git status`, `git log`, `ls`, `grep` | Runners (`go test -json`); third-party filters via `filter install` |
+| `Rewrite()` | Injects flags for `git status`, `git log`, `ls`, `grep`, `go test -json` | Runners (cargo, pytest, …); third-party filters via `filter install` |
 | `Read` / MCP | `PostToolUse` | `/* */` on Read; native `Grep`/`Glob` |
 | `gain` | Every proxy execution | Per-filter attribution by `id` |
-| Commands | find, ls, git (incl. show/write/stash), grep, rg, cat/head/tail, tree, Read, MCP | Runners; filter plugin registry (§4) |
+| Commands | find, ls, git (incl. show/write/stash), grep, rg, cat/head/tail, tree, go test/build/vet, Read, MCP | cargo, pytest, npm, docker; filter plugin registry (§4) |
 
 Filtering stays heuristic. No semantic compression.
 
@@ -236,7 +236,7 @@ Filtering stays heuristic. No semantic compression.
 
 1. PreToolUse proxy + end-to-end `git status` (section 1) — **done in 0.4.0**.
 2. Corrections to current modules + `cat`/`head`/`tail`/`tree` + remaining git (section 2) — **done in 0.5.0**.
-3. Runners (section 3).
+3. Runners (section 3) — **`go test`/`build`/`vet` done in 0.6.0**; cargo, pytest, npm, docker remain.
 4. Filter plugin registry + install/uninstall/list + migrate natives to `gtkai/gtkai-*` (section 4).
 5. Ecosystem commands as third-party filters according to `gain` (section 3 ecosystem).
 

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jmeiracorbal/gtk-ai/modules/mcpscan"
 
 	_ "github.com/jmeiracorbal/gtk-ai/modules/find"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/go"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
@@ -21,7 +22,7 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
 
-const version = "0.5.0"
+const version = "0.6.0"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s

--- a/internal/shell/rewrite_test.go
+++ b/internal/shell/rewrite_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/jmeiracorbal/gtk-ai/modules/find"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/go"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
@@ -11,6 +12,13 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
+
+func TestRewriteGoTest(t *testing.T) {
+	got, ok := Rewrite("go test ./...", "gtkai")
+	if !ok || got != "gtkai go test ./..." {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
 
 func TestRewriteGitStatus(t *testing.T) {
 	got, ok := Rewrite("git status", "gtkai")

--- a/modules/go/go.go
+++ b/modules/go/go.go
@@ -1,0 +1,295 @@
+// Package gocmd filters go test/build/vet output for Claude Code.
+package gocmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+const (
+	maxBuildVetLines = 200
+)
+
+func init() {
+	registry.Register(&Module{})
+}
+
+type Module struct{}
+
+func (m *Module) Name() string { return "go" }
+
+func (m *Module) Rewrite(args []string) ([]string, bool) {
+	globals, sub, rest, ok := splitGoArgs(args)
+	if !ok || sub != "test" {
+		return nil, false
+	}
+	if hasFlag(rest, "-json") || hasFlag(rest, "-bench") {
+		return nil, false
+	}
+	out := append(append([]string{}, globals...), "test", "-json")
+	out = append(out, rest...)
+	return out, true
+}
+
+func (m *Module) FilterOutput(args []string, output string, exitCode int) string {
+	_, sub, _, ok := splitGoArgs(args)
+	if !ok {
+		return output
+	}
+	switch sub {
+	case "test":
+		return filterTest(output)
+	case "build", "vet":
+		return filterBuildVet(output, exitCode)
+	default:
+		return output
+	}
+}
+
+func (m *Module) TokensBefore(output string) int {
+	return registry.EstimateTokens(output)
+}
+
+func (m *Module) TokensAfter(filtered string) int {
+	return registry.EstimateTokens(filtered)
+}
+
+type testEvent struct {
+	Action  string  `json:"Action"`
+	Package string  `json:"Package"`
+	Test    string  `json:"Test"`
+	Output  string  `json:"Output"`
+	Elapsed float64 `json:"Elapsed"`
+}
+
+type pkgState struct {
+	status  string
+	elapsed float64
+	outputs []string
+}
+
+func filterTest(output string) string {
+	if filtered, ok := filterTestJSON(output); ok {
+		return filtered
+	}
+	return filterTestClassic(output)
+}
+
+func filterTestJSON(output string) (string, bool) {
+	lines := strings.Split(output, "\n")
+	pkgs := make(map[string]*pkgState)
+	var pkgOrder []string
+
+	getPkg := func(name string) *pkgState {
+		if pkgs[name] == nil {
+			pkgs[name] = &pkgState{}
+			pkgOrder = append(pkgOrder, name)
+		}
+		return pkgs[name]
+	}
+
+	jsonLines := 0
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var ev testEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		jsonLines++
+		if ev.Package == "" {
+			continue
+		}
+		p := getPkg(ev.Package)
+		switch ev.Action {
+		case "output":
+			if ev.Output != "" {
+				p.outputs = append(p.outputs, ev.Output)
+			}
+		case "pass", "fail", "skip":
+			if ev.Test == "" {
+				p.status = ev.Action
+				if ev.Elapsed > 0 {
+					p.elapsed = ev.Elapsed
+				}
+			} else if ev.Action == "fail" {
+				p.status = "fail"
+			}
+		}
+	}
+	if jsonLines == 0 {
+		return "", false
+	}
+
+	var okCount int
+	var totalElapsed float64
+	var failSB strings.Builder
+
+	for _, name := range pkgOrder {
+		p := pkgs[name]
+		switch p.status {
+		case "pass", "skip":
+			okCount++
+			totalElapsed += p.elapsed
+		case "fail":
+			failSB.WriteString("FAIL\t")
+			failSB.WriteString(name)
+			if p.elapsed > 0 {
+				fmt.Fprintf(&failSB, "\t%.3fs\n", p.elapsed)
+			} else {
+				failSB.WriteByte('\n')
+			}
+			for _, o := range p.outputs {
+				failSB.WriteString(o)
+			}
+		default:
+			if len(p.outputs) > 0 {
+				p.status = "fail"
+				failSB.WriteString("FAIL\t")
+				failSB.WriteString(name)
+				failSB.WriteByte('\n')
+				for _, o := range p.outputs {
+					failSB.WriteString(o)
+				}
+			}
+		}
+	}
+
+	var sb strings.Builder
+	if okCount > 0 {
+		if totalElapsed > 0 {
+			fmt.Fprintf(&sb, "%d packages ok (%.1fs total)\n", okCount, totalElapsed)
+		} else {
+			fmt.Fprintf(&sb, "%d packages ok\n", okCount)
+		}
+	}
+	if failSB.Len() > 0 {
+		if sb.Len() > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(failSB.String())
+	}
+	if sb.Len() == 0 {
+		return output, true
+	}
+	if !strings.HasSuffix(sb.String(), "\n") {
+		sb.WriteByte('\n')
+	}
+	return sb.String(), true
+}
+
+func filterTestClassic(output string) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	okCount := 0
+	failIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "ok  \t") || strings.HasPrefix(line, "ok\t") {
+			okCount++
+			continue
+		}
+		if strings.HasPrefix(line, "FAIL\t") && failIdx < 0 {
+			failIdx = i
+		}
+	}
+	if failIdx < 0 {
+		if okCount > 0 && okCount == countClassicResults(lines) {
+			return fmt.Sprintf("%d packages ok\n", okCount)
+		}
+		return output
+	}
+	var sb strings.Builder
+	if okCount > 0 {
+		fmt.Fprintf(&sb, "%d packages ok\n\n", okCount)
+	}
+	sb.WriteString(strings.Join(lines[failIdx:], "\n"))
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+func countClassicResults(lines []string) int {
+	n := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "ok  \t") || strings.HasPrefix(line, "ok\t") ||
+			strings.HasPrefix(line, "FAIL\t") {
+			n++
+		}
+	}
+	return n
+}
+
+func filterBuildVet(output string, exitCode int) string {
+	if exitCode != 0 {
+		return capLines(output, maxBuildVetLines)
+	}
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return "ok\n"
+	}
+	if len(strings.Split(trimmed, "\n")) <= 5 {
+		return output
+	}
+	return "ok\n"
+}
+
+func capLines(output string, max int) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if len(lines) <= max {
+		return output
+	}
+	var sb strings.Builder
+	for _, l := range lines[:max] {
+		sb.WriteString(l)
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(fmt.Sprintf("... (%d lines truncated)\n", len(lines)-max))
+	return sb.String()
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+		if strings.HasPrefix(a, flag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func splitGoArgs(args []string) (globals []string, sub string, rest []string, ok bool) {
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		switch {
+		case a == "-C" || a == "-mod" || a == "-modfile" || a == "-overlay" ||
+			a == "-p" || a == "-tags" || a == "-toolexec" || a == "-gcflags" ||
+			a == "-ldflags" || a == "-asmflags" || a == "-compiler" ||
+			a == "-installsuffix" || a == "-pkgdir" || a == "-buildmode":
+			if i+1 >= len(args) {
+				return nil, "", nil, false
+			}
+			globals = append(globals, a, args[i+1])
+			i += 2
+		case strings.HasPrefix(a, "-mod=") || strings.HasPrefix(a, "-modfile=") ||
+			strings.HasPrefix(a, "-overlay=") || strings.HasPrefix(a, "-tags="):
+			globals = append(globals, a)
+			i++
+		case a == "-modcacherw" || a == "-work" || a == "-a" || a == "-n" || a == "-x" ||
+			a == "-race" || a == "-msan" || a == "-asan":
+			globals = append(globals, a)
+			i++
+		default:
+			if strings.HasPrefix(a, "-") {
+				return nil, "", nil, false
+			}
+			return globals, a, args[i+1:], true
+		}
+	}
+	return globals, "", nil, false
+}

--- a/modules/go/go_test.go
+++ b/modules/go/go_test.go
@@ -1,0 +1,140 @@
+package gocmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+func TestRewriteTestInjectsJSON(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"test", "./..."})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	want := []string{"test", "-json", "./..."}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestRewriteTestKeepsGlobals(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"-C", "/tmp", "test", "./..."})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	want := []string{"-C", "/tmp", "test", "-json", "./..."}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestRewriteTestSkipsJSON(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"test", "-json", "./..."})
+	if ok {
+		t.Fatal("user -json must not be rewritten")
+	}
+}
+
+func TestRewriteTestSkipsBench(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"test", "-bench=.", "./..."})
+	if ok {
+		t.Fatal("bench must not inject -json")
+	}
+	_, ok = m.Rewrite([]string{"test", "-bench", "."})
+	if ok {
+		t.Fatal("-bench must not inject -json")
+	}
+}
+
+func TestRewriteNonTest(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"build", "./..."})
+	if ok {
+		t.Fatal("build must not inject -json")
+	}
+}
+
+func TestFilterTestJSONManyOkOneFail(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 40; i++ {
+		pkg := fmt.Sprintf("example.com/ok%d", i)
+		writeEvent(&sb, testEvent{Action: "pass", Package: pkg, Elapsed: 0.001})
+	}
+	writeEvent(&sb, testEvent{Action: "output", Package: "example.com/fail", Output: "--- FAIL: TestBroken (0.00s)\n"})
+	writeEvent(&sb, testEvent{Action: "output", Package: "example.com/fail", Output: "    fail_test.go:10: boom\n"})
+	writeEvent(&sb, testEvent{Action: "fail", Package: "example.com/fail", Elapsed: 0.002})
+
+	m := &Module{}
+	out := m.FilterOutput([]string{"test", "./..."}, sb.String(), 1)
+	if !strings.Contains(out, "40 packages ok") {
+		t.Fatalf("expected ok count, got %q", out)
+	}
+	if !strings.Contains(out, "FAIL\texample.com/fail") {
+		t.Fatalf("expected FAIL package, got %q", out)
+	}
+	if !strings.Contains(out, "TestBroken") || !strings.Contains(out, "boom") {
+		t.Fatalf("expected failure details, got %q", out)
+	}
+	if registry.EstimateTokens(out) >= registry.EstimateTokens(sb.String()) {
+		t.Fatal("filtered output should use fewer tokens than raw JSON")
+	}
+}
+
+func TestFilterTestClassicManyOkOneFail(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&sb, "ok  \texample.com/ok%d\t0.001s\n", i)
+	}
+	sb.WriteString("FAIL\texample.com/fail\t0.002s\n")
+	sb.WriteString("--- FAIL: TestBroken (0.00s)\n")
+	sb.WriteString("    fail_test.go:10: boom\n")
+	sb.WriteString("FAIL\n")
+	sb.WriteString("FAIL\texample.com/fail\t0.002s\n")
+
+	m := &Module{}
+	out := m.FilterOutput([]string{"test", "./..."}, sb.String(), 1)
+	if !strings.Contains(out, "40 packages ok") {
+		t.Fatalf("expected ok count, got %q", out)
+	}
+	if !strings.Contains(out, "TestBroken") {
+		t.Fatalf("expected failure details, got %q", out)
+	}
+}
+
+func TestFilterBuildVetSuccess(t *testing.T) {
+	m := &Module{}
+	out := m.FilterOutput([]string{"build", "./..."}, "", 0)
+	if out != "ok\n" {
+		t.Fatalf("got %q", out)
+	}
+	out = m.FilterOutput([]string{"vet", "./..."}, "", 0)
+	if out != "ok\n" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestFilterBuildFailurePassthrough(t *testing.T) {
+	raw := "# example.com/fail\n./main.go:1:1: syntax error\n"
+	m := &Module{}
+	out := m.FilterOutput([]string{"build", "./..."}, raw, 1)
+	if !strings.Contains(out, "syntax error") {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func writeEvent(sb *strings.Builder, ev testEvent) {
+	b, err := json.Marshal(ev)
+	if err != nil {
+		panic(err)
+	}
+	sb.Write(b)
+	sb.WriteByte('\n')
+}

--- a/modules/mcpscan/mcpscan.go
+++ b/modules/mcpscan/mcpscan.go
@@ -247,7 +247,7 @@ func mcpHandshake(w io.Writer, r io.Reader) ([]string, error) {
 		Params: map[string]interface{}{
 			"protocolVersion": "2024-11-05",
 			"capabilities":    map[string]interface{}{},
-			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.5.0"},
+			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.6.0"},
 		},
 	}); err != nil {
 		return nil, err

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "jmeiracorbal"
   },


### PR DESCRIPTION

## Summary

Adds the first §3 runner: a `go` module that rewrites `go test` to use `-json` and compacts output before it reaches the agent.

- **Rewrite:** injects `-json` on `go test` unless `-json` or `-bench` is already present; respects global flags (`-C`, `-mod`, …).
- **Filter (test):** JSON stream parser collapses passing packages to a count; keeps full output for failures. Falls back to classic `ok`/`FAIL` text when output is not JSON.
- **Filter (build/vet):** silent success → `ok\n`; failures capped at 200 lines.
- **PreToolUse:** `go test ./...` rewrites to `gtkai go test ./...` like other registered commands.

## Tests

- Fixture with 40 passing packages + 1 failure (JSON and classic formats)
- Rewrite and shell rewrite tests
- `go test ./...` green

## Version

Bumps to **0.6.0** across all version-bearing files.

## Roadmap

§3 partial: `gotest` row done. Next: cargo runner.
