### PR TITLE
feat: add cargo runner with quiet rewrite and compile collapse (0.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "gtk-ai",
       "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Two independent phases:
 
 Never collapse both phases into one. The plugin depends on the binary. The binary does not configure Claude Code.
 
-Target flow and remaining work: `ROADMAP.md`. `0.6.0` adds the `go test` runner (§3).
+Target flow and remaining work: `ROADMAP.md`. `0.7.0` adds the cargo runner (§3).
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gtk-ai
 
 ![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go&logoColor=white)
-![Version](https://img.shields.io/badge/version-0.6.0-blue?style=flat)
+![Version](https://img.shields.io/badge/version-0.7.0-blue?style=flat)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin%20compatible-blueviolet?style=flat)
 ![Build](https://img.shields.io/badge/build-passing-brightgreen?style=flat)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap: gtk-ai vs rtk 0.42.4
 
-Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.6.0`.
+Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.7.0`.
 
 **Product decision (2026-08-17):** gtk follows the same path as rtk. It rewrites the command **before** execution (`PreToolUse` → `git status` becomes `gtkai git status`). gtkai runs the real binary, injects flags, and filters the output. Post-filtering remains only for Claude Code native tools that do not go through Bash (`Read`, MCP, `Grep`, `Glob`).
 
@@ -108,7 +108,7 @@ Only after the proxy and the corrections. Here rewrite does inject flags (`go te
 | Module | Commands | Rewrite | Filter |
 |---|---|---|---|
 | `gotest` | `go test`, `go build`, `go vet` | `go test -json` unless `-bench` or `-json` is already present | `ok` packages → count; full `FAIL` — **done in 0.6.0** |
-| `cargo` | `test`, `build`, `clippy`, `check` | by subcommand | errors/failures; collapse `Compiling` |
+| `cargo` | `test`, `build`, `clippy`, `check` | by subcommand | errors/failures; collapse `Compiling` — **done in 0.7.0** |
 | `pytest` | `pytest`, `python -m pytest` | — | failures + short traceback |
 | `npmtest` | `npm test`, `pnpm test`, `npx vitest`/`jest` | — | failures; strip ANSI |
 | `docker` | `ps`, `images`, `logs`, `compose ps/logs` | — | essential columns; capped logs |
@@ -207,14 +207,14 @@ Done when: native `gtkai/gtkai-*` filters use the same registry; install/uninsta
 
 ## Current vs target
 
-| | gtk-ai 0.6.0 | Remaining |
+| | gtk-ai 0.7.0 | Remaining |
 |---|---|---|
 | Bash | `PreToolUse` rewrites registered commands to `gtkai …`; the binary runs and filters | Bash removed from `PostToolUse` (0.5.0) |
 | Filter identity | Flat `registry.Get("ls")` | Namespaced `author/gtkai-<command>`; active = most recent install |
 | `Rewrite()` | Injects flags for `git status`, `git log`, `ls`, `grep`, `go test -json` | Runners (cargo, pytest, …); third-party filters via `filter install` |
 | `Read` / MCP | `PostToolUse` | `/* */` on Read; native `Grep`/`Glob` |
 | `gain` | Every proxy execution | Per-filter attribution by `id` |
-| Commands | find, ls, git (incl. show/write/stash), grep, rg, cat/head/tail, tree, go test/build/vet, Read, MCP | cargo, pytest, npm, docker; filter plugin registry (§4) |
+| Commands | find, ls, git (incl. show/write/stash), grep, rg, cat/head/tail, tree, go test/build/vet, cargo test/build/clippy/check, Read, MCP | pytest, npm, docker; filter plugin registry (§4) |
 
 Filtering stays heuristic. No semantic compression.
 
@@ -236,7 +236,7 @@ Filtering stays heuristic. No semantic compression.
 
 1. PreToolUse proxy + end-to-end `git status` (section 1) — **done in 0.4.0**.
 2. Corrections to current modules + `cat`/`head`/`tail`/`tree` + remaining git (section 2) — **done in 0.5.0**.
-3. Runners (section 3) — **`go test`/`build`/`vet` done in 0.6.0**; cargo, pytest, npm, docker remain.
+3. Runners (section 3) — **`go test`/`build`/`vet` done in 0.6.0**; **cargo done in 0.7.0**; pytest, npm, docker remain.
 4. Filter plugin registry + install/uninstall/list + migrate natives to `gtkai/gtkai-*` (section 4).
 5. Ecosystem commands as third-party filters according to `gain` (section 3 ecosystem).
 

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmeiracorbal/gtk-ai/modules/gain"
 	"github.com/jmeiracorbal/gtk-ai/modules/mcpscan"
 
+	_ "github.com/jmeiracorbal/gtk-ai/modules/cargo"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/find"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/go"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
@@ -22,7 +23,7 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
 
-const version = "0.6.0"
+const version = "0.7.0"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s

--- a/internal/shell/rewrite_test.go
+++ b/internal/shell/rewrite_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"testing"
 
+	_ "github.com/jmeiracorbal/gtk-ai/modules/cargo"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/find"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/go"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
@@ -12,6 +13,13 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
+
+func TestRewriteCargoTest(t *testing.T) {
+	got, ok := Rewrite("cargo test", "gtkai")
+	if !ok || got != "gtkai cargo test" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
 
 func TestRewriteGoTest(t *testing.T) {
 	got, ok := Rewrite("go test ./...", "gtkai")

--- a/modules/cargo/cargo.go
+++ b/modules/cargo/cargo.go
@@ -1,0 +1,245 @@
+// Package cargo filters cargo test/build/clippy/check output for Claude Code.
+package cargo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+const (
+	maxFailureLines   = 300
+	compileLinePrefix = "Compiling "
+	checkLinePrefix   = "Checking "
+)
+
+var handledSubs = map[string]struct{}{
+	"test": {}, "build": {}, "check": {}, "clippy": {},
+}
+
+func init() {
+	registry.Register(&Module{})
+}
+
+type Module struct{}
+
+func (m *Module) Name() string { return "cargo" }
+
+func (m *Module) Rewrite(args []string) ([]string, bool) {
+	globals, sub, rest, ok := splitCargoArgs(args)
+	if !ok {
+		return nil, false
+	}
+	if _, handled := handledSubs[sub]; !handled {
+		return nil, false
+	}
+	if hasQuiet(globals, rest) || hasVerbose(globals, rest) {
+		return nil, false
+	}
+	out := append(append([]string{}, globals...), sub, "-q")
+	out = append(out, rest...)
+	return out, true
+}
+
+func (m *Module) FilterOutput(args []string, output string, exitCode int) string {
+	_, sub, _, ok := splitCargoArgs(args)
+	if !ok {
+		return output
+	}
+	if _, handled := handledSubs[sub]; !handled {
+		return output
+	}
+	if exitCode != 0 {
+		return filterFailure(output)
+	}
+	return filterSuccess(output)
+}
+
+func (m *Module) TokensBefore(output string) int {
+	return registry.EstimateTokens(output)
+}
+
+func (m *Module) TokensAfter(filtered string) int {
+	return registry.EstimateTokens(filtered)
+}
+
+func filterSuccess(output string) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	compileCount := 0
+	var kept []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isCompileLine(trimmed) {
+			compileCount++
+			continue
+		}
+		if trimmed == "" {
+			continue
+		}
+		if isPassingTestLine(trimmed) {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "running ") && strings.Contains(trimmed, " test") {
+			continue
+		}
+		if shouldKeepSuccessLine(trimmed) {
+			kept = append(kept, line)
+		}
+	}
+
+	var sb strings.Builder
+	if compileCount > 0 {
+		fmt.Fprintf(&sb, "Compiling %d crates\n", compileCount)
+	}
+	for _, l := range kept {
+		sb.WriteString(l)
+		sb.WriteByte('\n')
+	}
+	if sb.Len() == 0 {
+		return "ok\n"
+	}
+	result := sb.String()
+	if hasTestResult(result) {
+		return result
+	}
+	if compileCount > 0 && len(kept) <= 2 {
+		return result
+	}
+	if strings.TrimSpace(result) == "" {
+		return "ok\n"
+	}
+	return result
+}
+
+func filterFailure(output string) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	compileCount := 0
+	var kept []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isCompileLine(trimmed) {
+			compileCount++
+			continue
+		}
+		kept = append(kept, line)
+	}
+
+	var sb strings.Builder
+	if compileCount > 0 {
+		fmt.Fprintf(&sb, "Compiling %d crates\n", compileCount)
+	}
+	for _, l := range kept {
+		sb.WriteString(l)
+		sb.WriteByte('\n')
+	}
+	result := sb.String()
+	if len(kept) > maxFailureLines {
+		return capLines(result, maxFailureLines)
+	}
+	return result
+}
+
+func isCompileLine(trimmed string) bool {
+	return strings.HasPrefix(trimmed, compileLinePrefix) ||
+		strings.HasPrefix(trimmed, checkLinePrefix)
+}
+
+func isPassingTestLine(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "test ") && strings.Contains(trimmed, "... ok")
+}
+
+func shouldKeepSuccessLine(trimmed string) bool {
+	switch {
+	case strings.HasPrefix(trimmed, "Finished"):
+		return true
+	case strings.HasPrefix(trimmed, "test result:"):
+		return true
+	case strings.HasPrefix(trimmed, "Doc-tests"):
+		return true
+	case strings.HasPrefix(trimmed, "Running "):
+		return true
+	default:
+		return false
+	}
+}
+
+func hasTestResult(out string) bool {
+	return strings.Contains(out, "test result:")
+}
+
+func capLines(output string, max int) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if len(lines) <= max {
+		return output
+	}
+	var sb strings.Builder
+	for _, l := range lines[:max] {
+		sb.WriteString(l)
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(fmt.Sprintf("... (%d lines truncated)\n", len(lines)-max))
+	return sb.String()
+}
+
+func hasQuiet(globals, rest []string) bool {
+	return hasFlag(globals, "-q", "--quiet") || hasFlag(rest, "-q", "--quiet")
+}
+
+func hasVerbose(globals, rest []string) bool {
+	return hasFlag(globals, "-v", "-vv", "--verbose") ||
+		hasFlag(rest, "-v", "-vv", "--verbose")
+}
+
+func hasFlag(args []string, flags ...string) bool {
+	for _, a := range args {
+		for _, f := range flags {
+			if a == f {
+				return true
+			}
+			if strings.HasPrefix(a, f+"=") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func splitCargoArgs(args []string) (globals []string, sub string, rest []string, ok bool) {
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		switch {
+		case a == "--manifest-path" || a == "--config" || a == "--color" ||
+			a == "--target" || a == "--target-dir" || a == "--timings" ||
+			a == "-p" || a == "--package" || a == "--exclude" ||
+			a == "--features" || a == "-j" || a == "--jobs":
+			if i+1 >= len(args) {
+				return nil, "", nil, false
+			}
+			globals = append(globals, a, args[i+1])
+			i += 2
+		case strings.HasPrefix(a, "--manifest-path=") || strings.HasPrefix(a, "--config=") ||
+			strings.HasPrefix(a, "--color=") || strings.HasPrefix(a, "--target=") ||
+			strings.HasPrefix(a, "--target-dir=") || strings.HasPrefix(a, "--features=") ||
+			strings.HasPrefix(a, "--exclude=") || strings.HasPrefix(a, "--package="):
+			globals = append(globals, a)
+			i++
+		case a == "-q" || a == "--quiet" || a == "-v" || a == "-vv" || a == "--verbose" ||
+			a == "--release" || a == "--frozen" || a == "--locked" || a == "--offline" ||
+			a == "--workspace" || a == "--all-features" || a == "--no-default-features" ||
+			a == "--keep-going" || a == "--all-targets" || a == "--lib" || a == "--bins" ||
+			a == "--tests" || a == "--benches" || a == "--examples":
+			globals = append(globals, a)
+			i++
+		default:
+			if strings.HasPrefix(a, "-") {
+				return nil, "", nil, false
+			}
+			return globals, a, args[i+1:], true
+		}
+	}
+	return globals, "", nil, false
+}

--- a/modules/cargo/cargo_test.go
+++ b/modules/cargo/cargo_test.go
@@ -1,0 +1,123 @@
+package cargo
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+func TestRewriteTestInjectsQuiet(t *testing.T) {
+	m := &Module{}
+	got, ok := m.Rewrite([]string{"test"})
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	want := []string{"test", "-q"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestRewriteBuildClippyCheck(t *testing.T) {
+	m := &Module{}
+	for _, sub := range []string{"build", "check", "clippy"} {
+		got, ok := m.Rewrite([]string{sub})
+		if !ok {
+			t.Fatalf("%s: expected rewrite", sub)
+		}
+		want := []string{sub, "-q"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s: got %v want %v", sub, got, want)
+		}
+	}
+}
+
+func TestRewriteSkipsVerbose(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"test", "-v"})
+	if ok {
+		t.Fatal("verbose must not rewrite")
+	}
+	_, ok = m.Rewrite([]string{"-v", "test"})
+	if ok {
+		t.Fatal("global verbose must not rewrite")
+	}
+}
+
+func TestRewriteSkipsQuiet(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"test", "-q"})
+	if ok {
+		t.Fatal("already quiet must not rewrite")
+	}
+}
+
+func TestRewriteNonHandled(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"run"})
+	if ok {
+		t.Fatal("run must not rewrite")
+	}
+}
+
+func TestFilterSuccessCollapsesCompiling(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 20; i++ {
+		fmt.Fprintf(&sb, "   Compiling crate%d v0.1.0\n", i)
+	}
+	sb.WriteString("    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.00s\n")
+	sb.WriteString("     Running unittests src/lib.rs (target/debug/deps/foo)\n")
+	sb.WriteString("running 10 tests\n")
+	for i := 0; i < 10; i++ {
+		fmt.Fprintf(&sb, "test test_%d ... ok\n", i)
+	}
+	sb.WriteString("test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s\n")
+
+	m := &Module{}
+	out := m.FilterOutput([]string{"test"}, sb.String(), 0)
+	if !strings.Contains(out, "Compiling 20 crates") {
+		t.Fatalf("expected compile count, got %q", out)
+	}
+	if strings.Contains(out, "test test_0") {
+		t.Fatalf("passing test lines should be collapsed, got %q", out)
+	}
+	if !strings.Contains(out, "test result: ok. 10 passed") {
+		t.Fatalf("expected test result, got %q", out)
+	}
+	if registry.EstimateTokens(out) >= registry.EstimateTokens(sb.String()) {
+		t.Fatal("filtered output should use fewer tokens")
+	}
+}
+
+func TestFilterFailureKeepsErrors(t *testing.T) {
+	raw := `   Compiling foo v0.1.0
+   Compiling bar v0.1.0
+error[E0425]: cannot find value ` + "`x`" + ` in this scope
+ --> src/main.rs:1:5
+  |
+1 |     x
+  |     ^ not found in this scope
+
+error: test failed, to rerun pass ` + "`--bin foo`" + `
+`
+	m := &Module{}
+	out := m.FilterOutput([]string{"test"}, raw, 101)
+	if !strings.Contains(out, "Compiling 2 crates") {
+		t.Fatalf("expected compile count, got %q", out)
+	}
+	if !strings.Contains(out, "error[E0425]") || !strings.Contains(out, "not found in this scope") {
+		t.Fatalf("expected error details, got %q", out)
+	}
+}
+
+func TestFilterBuildSuccessMinimal(t *testing.T) {
+	raw := "   Compiling foo v0.1.0\n    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s\n"
+	m := &Module{}
+	out := m.FilterOutput([]string{"build"}, raw, 0)
+	if !strings.Contains(out, "Compiling 1 crates") || !strings.Contains(out, "Finished") {
+		t.Fatalf("got %q", out)
+	}
+}

--- a/modules/mcpscan/mcpscan.go
+++ b/modules/mcpscan/mcpscan.go
@@ -247,7 +247,7 @@ func mcpHandshake(w io.Writer, r io.Reader) ([]string, error) {
 		Params: map[string]interface{}{
 			"protocolVersion": "2024-11-05",
 			"capabilities":    map[string]interface{}{},
-			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.6.0"},
+			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.7.0"},
 		},
 	}); err != nil {
 		return nil, err

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "jmeiracorbal"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the cargo runner (§3): a `cargo` module that rewrites common subcommands to quiet mode and compacts build/test output.

- **Rewrite:** injects `-q` on `cargo test`, `build`, `check`, and `clippy` unless `-q`/`--quiet` or `-v`/`--verbose` is already present.
- **Filter (success):** collapses `Compiling`/`Checking` lines to a count; drops individual passing `test … ok` lines; keeps `Finished` and `test result:`.
- **Filter (failure):** collapses compile noise; preserves full error output (capped at 300 lines).
- **PreToolUse:** `cargo test` rewrites to `gtkai cargo test` like other registered commands.

## Tests

- Rewrite for all four subcommands; skips verbose/quiet/already-handled cases
- Success fixture with 20 compile lines + 10 passing tests
- Failure fixture preserving rustc errors
- `go test ./...` green

## Version

Bumps to **0.7.0** across all version-bearing files.

## Roadmap

§3 partial: `cargo` row done. Next: pytest runner.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a010d2-9511-771b-a0c6-f6999e0b718a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a010d2-9511-771b-a0c6-f6999e0b718a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

