### PR TITLE
feat: add pytest runner with failure traceback filter (0.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "gtk-ai",
       "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Two independent phases:
 
 Never collapse both phases into one. The plugin depends on the binary. The binary does not configure Claude Code.
 
-Target flow and remaining work: `ROADMAP.md`. `0.7.0` adds the cargo runner (§3).
+Target flow and remaining work: `ROADMAP.md`. `0.8.0` adds the pytest runner (§3).
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gtk-ai
 
 ![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go&logoColor=white)
-![Version](https://img.shields.io/badge/version-0.7.0-blue?style=flat)
+![Version](https://img.shields.io/badge/version-0.8.0-blue?style=flat)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin%20compatible-blueviolet?style=flat)
 ![Build](https://img.shields.io/badge/build-passing-brightgreen?style=flat)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap: gtk-ai vs rtk 0.42.4
 
-Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.7.0`.
+Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.8.0`.
 
 **Product decision (2026-08-17):** gtk follows the same path as rtk. It rewrites the command **before** execution (`PreToolUse` → `git status` becomes `gtkai git status`). gtkai runs the real binary, injects flags, and filters the output. Post-filtering remains only for Claude Code native tools that do not go through Bash (`Read`, MCP, `Grep`, `Glob`).
 
@@ -109,7 +109,7 @@ Only after the proxy and the corrections. Here rewrite does inject flags (`go te
 |---|---|---|---|
 | `gotest` | `go test`, `go build`, `go vet` | `go test -json` unless `-bench` or `-json` is already present | `ok` packages → count; full `FAIL` — **done in 0.6.0** |
 | `cargo` | `test`, `build`, `clippy`, `check` | by subcommand | errors/failures; collapse `Compiling` — **done in 0.7.0** |
-| `pytest` | `pytest`, `python -m pytest` | — | failures + short traceback |
+| `pytest` | `pytest`, `python -m pytest` | — | failures + short traceback — **done in 0.8.0** |
 | `npmtest` | `npm test`, `pnpm test`, `npx vitest`/`jest` | — | failures; strip ANSI |
 | `docker` | `ps`, `images`, `logs`, `compose ps/logs` | — | essential columns; capped logs |
 
@@ -207,14 +207,14 @@ Done when: native `gtkai/gtkai-*` filters use the same registry; install/uninsta
 
 ## Current vs target
 
-| | gtk-ai 0.7.0 | Remaining |
+| | gtk-ai 0.8.0 | Remaining |
 |---|---|---|
 | Bash | `PreToolUse` rewrites registered commands to `gtkai …`; the binary runs and filters | Bash removed from `PostToolUse` (0.5.0) |
 | Filter identity | Flat `registry.Get("ls")` | Namespaced `author/gtkai-<command>`; active = most recent install |
 | `Rewrite()` | Injects flags for `git status`, `git log`, `ls`, `grep`, `go test -json` | Runners (cargo, pytest, …); third-party filters via `filter install` |
 | `Read` / MCP | `PostToolUse` | `/* */` on Read; native `Grep`/`Glob` |
 | `gain` | Every proxy execution | Per-filter attribution by `id` |
-| Commands | find, ls, git (incl. show/write/stash), grep, rg, cat/head/tail, tree, go test/build/vet, cargo test/build/clippy/check, Read, MCP | pytest, npm, docker; filter plugin registry (§4) |
+| Commands | find, ls, git, grep, rg, cat/head/tail, tree, go test/build/vet, cargo test/build/clippy/check, pytest, Read, MCP | npm, docker; filter plugin registry (§4) |
 
 Filtering stays heuristic. No semantic compression.
 
@@ -236,7 +236,7 @@ Filtering stays heuristic. No semantic compression.
 
 1. PreToolUse proxy + end-to-end `git status` (section 1) — **done in 0.4.0**.
 2. Corrections to current modules + `cat`/`head`/`tail`/`tree` + remaining git (section 2) — **done in 0.5.0**.
-3. Runners (section 3) — **`go test`/`build`/`vet` done in 0.6.0**; **cargo done in 0.7.0**; pytest, npm, docker remain.
+3. Runners (section 3) — **`go test`/`build`/`vet` done in 0.6.0**; **cargo done in 0.7.0**; **pytest done in 0.8.0**; npm, docker remain.
 4. Filter plugin registry + install/uninstall/list + migrate natives to `gtkai/gtkai-*` (section 4).
 5. Ecosystem commands as third-party filters according to `gain` (section 3 ecosystem).
 

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -18,12 +18,13 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
-	_ "github.com/jmeiracorbal/gtk-ai/modules/readcmd"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/pytest"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/python"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
 
-const version = "0.7.0"
+const version = "0.8.0"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s

--- a/internal/shell/rewrite_test.go
+++ b/internal/shell/rewrite_test.go
@@ -9,10 +9,30 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/pytest"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/python"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/readcmd"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/rg"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
+
+func TestRewritePytest(t *testing.T) {
+	got, ok := Rewrite("pytest -v", "gtkai")
+	if !ok || got != "gtkai pytest -v" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
+
+func TestRewritePythonMPytest(t *testing.T) {
+	got, ok := Rewrite("python -m pytest", "gtkai")
+	if !ok || got != "gtkai python -m pytest" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+	got, ok = Rewrite("python3 -m pytest tests/", "gtkai")
+	if !ok || got != "gtkai python3 -m pytest tests/" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
 
 func TestRewriteCargoTest(t *testing.T) {
 	got, ok := Rewrite("cargo test", "gtkai")

--- a/modules/mcpscan/mcpscan.go
+++ b/modules/mcpscan/mcpscan.go
@@ -247,7 +247,7 @@ func mcpHandshake(w io.Writer, r io.Reader) ([]string, error) {
 		Params: map[string]interface{}{
 			"protocolVersion": "2024-11-05",
 			"capabilities":    map[string]interface{}{},
-			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.7.0"},
+			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.8.0"},
 		},
 	}); err != nil {
 		return nil, err

--- a/modules/pytest/filter.go
+++ b/modules/pytest/filter.go
@@ -1,0 +1,128 @@
+package pytest
+
+import (
+	"strings"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+const maxFailureDetail = 50
+
+// Filter compacts pytest stdout: summary on success; failures + short traceback on error.
+func Filter(output string, exitCode int) string {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	summary := extractSummary(lines)
+
+	if exitCode == 0 {
+		if summary != "" {
+			return registry.NeverWorse(output, summary+"\n")
+		}
+		return output
+	}
+
+	filtered := filterFailure(lines, summary)
+	if filtered == "" {
+		return output
+	}
+	return registry.NeverWorse(output, filtered)
+}
+
+func filterFailure(lines []string, summary string) string {
+	var sb strings.Builder
+	inFailures := false
+	inShort := false
+	detailLines := 0
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isFailuresHeader(trimmed) {
+			inFailures = true
+			inShort = false
+			continue
+		}
+		if isShortSummaryHeader(trimmed) {
+			inFailures = false
+			inShort = true
+			continue
+		}
+		if inShort {
+			if strings.HasPrefix(trimmed, "FAILED") || strings.HasPrefix(trimmed, "ERROR") {
+				sb.WriteString(line)
+				sb.WriteByte('\n')
+			}
+			if isBannerLine(trimmed) && !isShortSummaryHeader(trimmed) {
+				inShort = false
+			}
+			continue
+		}
+		if inFailures {
+			if isBannerLine(trimmed) && !isFailuresHeader(trimmed) {
+				inFailures = false
+				continue
+			}
+			if detailLines >= maxFailureDetail {
+				if trimmed == "" {
+					sb.WriteString("... (traceback truncated)\n")
+					inFailures = false
+				}
+				continue
+			}
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+			detailLines++
+			continue
+		}
+		if strings.HasPrefix(trimmed, "FAILED") || strings.HasPrefix(trimmed, "ERROR") {
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+	}
+
+	if summary != "" {
+		if sb.Len() > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(summary)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+func extractSummary(lines []string) string {
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
+		}
+		if isResultSummary(trimmed) {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func isResultSummary(line string) bool {
+	if strings.Contains(line, " passed") || strings.Contains(line, " failed") ||
+		strings.Contains(line, " error") {
+		if isBannerLine(line) {
+			return true
+		}
+		if strings.Contains(line, " in ") && (strings.Contains(line, "s") || strings.Contains(line, "ms")) {
+			return true
+		}
+	}
+	return false
+}
+
+func isBannerLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "=") && strings.HasSuffix(trimmed, "=")
+}
+
+func isFailuresHeader(line string) bool {
+	return isBannerLine(line) && strings.Contains(line, "FAILURES")
+}
+
+func isShortSummaryHeader(line string) bool {
+	return strings.Contains(strings.ToLower(line), "short test summary info")
+}

--- a/modules/pytest/pytest.go
+++ b/modules/pytest/pytest.go
@@ -1,0 +1,30 @@
+// Package pytest filters pytest command output for Claude Code.
+package pytest
+
+import (
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+func init() {
+	registry.Register(&Module{})
+}
+
+type Module struct{}
+
+func (m *Module) Name() string { return "pytest" }
+
+func (m *Module) Rewrite(args []string) ([]string, bool) {
+	return nil, false
+}
+
+func (m *Module) FilterOutput(args []string, output string, exitCode int) string {
+	return Filter(output, exitCode)
+}
+
+func (m *Module) TokensBefore(output string) int {
+	return registry.EstimateTokens(output)
+}
+
+func (m *Module) TokensAfter(filtered string) int {
+	return registry.EstimateTokens(filtered)
+}

--- a/modules/pytest/pytest_test.go
+++ b/modules/pytest/pytest_test.go
@@ -1,0 +1,71 @@
+package pytest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+)
+
+func TestFilterSuccessKeepsSummary(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("============================= test session starts ==============================\n")
+	sb.WriteString("collected 42 items\n")
+	for i := 0; i < 42; i++ {
+		fmt.Fprintf(&sb, "tests/test_%d.py .                                                             [ %2d%%]\n", i, (i+1)*100/42)
+	}
+	sb.WriteString("============================== 42 passed in 1.23s ==============================\n")
+
+	out := Filter(sb.String(), 0)
+	if !strings.Contains(out, "42 passed in 1.23s") {
+		t.Fatalf("got %q", out)
+	}
+	if strings.Contains(out, "collected") || strings.Contains(out, "test_0") {
+		t.Fatalf("noise should be removed, got %q", out)
+	}
+	if registry.EstimateTokens(out) >= registry.EstimateTokens(sb.String()) {
+		t.Fatal("filtered output should use fewer tokens")
+	}
+}
+
+func TestFilterFailureKeepsTracebackAndSummary(t *testing.T) {
+	raw := `============================= test session starts ==============================
+collected 2 items
+
+tests/test_fail.py F.                                                            [100%]
+
+=================================== FAILURES ===================================
+__________________________________ test_broken __________________________________
+
+    def test_broken():
+>       assert False
+E       AssertionError: assert False
+
+tests/test_fail.py:2: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_fail.py::test_broken - AssertionError: assert False
+========================= 1 failed, 1 passed in 0.05s =========================
+`
+	out := Filter(raw, 1)
+	if !strings.Contains(out, "AssertionError") {
+		t.Fatalf("expected traceback, got %q", out)
+	}
+	if !strings.Contains(out, "FAILED tests/test_fail.py::test_broken") {
+		t.Fatalf("expected short summary, got %q", out)
+	}
+	if !strings.Contains(out, "1 failed, 1 passed") {
+		t.Fatalf("expected result summary, got %q", out)
+	}
+	if strings.Contains(out, "collected 2 items") {
+		t.Fatalf("noise should be removed, got %q", out)
+	}
+}
+
+func TestModuleRewritePassthrough(t *testing.T) {
+	m := &Module{}
+	_, ok := m.Rewrite([]string{"-v"})
+	if ok {
+		t.Fatal("pytest must not rewrite")
+	}
+}

--- a/modules/python/python.go
+++ b/modules/python/python.go
@@ -1,0 +1,47 @@
+// Package python filters python -m pytest invocations for Claude Code.
+package python
+
+import (
+	"github.com/jmeiracorbal/gtk-ai/internal/registry"
+	"github.com/jmeiracorbal/gtk-ai/modules/pytest"
+)
+
+func init() {
+	registry.Register(&Module{name: "python"})
+	registry.Register(&Module{name: "python3"})
+}
+
+type Module struct {
+	name string
+}
+
+func (m *Module) Name() string { return m.name }
+
+func (m *Module) Rewrite(args []string) ([]string, bool) {
+	return nil, false
+}
+
+func (m *Module) FilterOutput(args []string, output string, exitCode int) string {
+	if !IsPytestInvocation(args) {
+		return output
+	}
+	return pytest.Filter(output, exitCode)
+}
+
+func (m *Module) TokensBefore(output string) int {
+	return registry.EstimateTokens(output)
+}
+
+func (m *Module) TokensAfter(filtered string) int {
+	return registry.EstimateTokens(filtered)
+}
+
+// IsPytestInvocation reports whether args invoke pytest via python -m.
+func IsPytestInvocation(args []string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "-m" && args[i+1] == "pytest" {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/python/python_test.go
+++ b/modules/python/python_test.go
@@ -1,0 +1,33 @@
+package python
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsPytestInvocation(t *testing.T) {
+	if !IsPytestInvocation([]string{"-m", "pytest", "-v"}) {
+		t.Fatal("expected pytest via -m")
+	}
+	if IsPytestInvocation([]string{"-m", "pip", "install", "pytest"}) {
+		t.Fatal("pip must not match")
+	}
+}
+
+func TestFilterOutputNonPytestPassthrough(t *testing.T) {
+	m := &Module{name: "python3"}
+	raw := "Hello from python\n"
+	out := m.FilterOutput([]string{"-c", "print('Hello from python')"}, raw, 0)
+	if out != raw {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestFilterOutputPytestUsesFilter(t *testing.T) {
+	m := &Module{name: "python3"}
+	raw := "collected 1 items\n============================== 1 passed in 0.01s ==============================\n"
+	out := m.FilterOutput([]string{"-m", "pytest"}, raw, 0)
+	if !strings.Contains(out, "1 passed in 0.01s") {
+		t.Fatalf("got %q", out)
+	}
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "jmeiracorbal"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the pytest runner (§3):

- **`pytest` module:** no rewrite; filters output on success and failure.
- **`python` / `python3` modules:** same filter when args include `-m pytest`; pass-through otherwise.
- **Filter (success):** keeps only the final `N passed in …` summary line.
- **Filter (failure):** keeps FAILURES section (capped), short test summary, and final result line; drops collection/progress noise.

## Tests

- Success fixture with 42 progress lines → summary only
- Failure fixture with traceback + short summary
- `python -m pytest` detection and pass-through for non-pytest invocations
- Shell rewrite for `pytest` and `python3 -m pytest`
- `go test ./...` green

## Version

Bumps to **0.8.0** across all version-bearing files.

## Roadmap

§3 partial: `pytest` row done. Next: npm/pnpm runner.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a010d2-9511-771b-a0c6-f6999e0b718a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a010d2-9511-771b-a0c6-f6999e0b718a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

