### PR TITLE
feat: soporte Cursor, Codex y OpenCode (0.10.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "metadata": {
-    "description": "PreToolUse rewrite and PostToolUse filtering for Claude Code. Applies rule-based output reduction to Bash, git, grep, find, ls, Read, and MCP tools."
+    "description": "PreToolUse rewrite and PostToolUse filtering for Claude Code, Cursor, Codex, and OpenCode. Applies rule-based output reduction to shell, git, grep, find, ls, Read, and MCP tools."
   },
   "owner": {
     "name": "jmeiracorbal",
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "gtk-ai",
-      "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-      "version": "0.9.0",
+      "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
+      "version": "0.10.0",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
-  "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.9.0",
+  "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
+  "version": "0.10.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,13 @@ jobs:
       - name: Check hook scripts are executable
         run: |
           failed=0
-          for f in plugin/scripts/gtkai-post-tool-use.sh plugin/scripts/gtkai-pre-tool-use.sh; do
+          for f in \
+            plugin/scripts/gtkai-post-tool-use.sh \
+            plugin/scripts/gtkai-pre-tool-use.sh \
+            scripts/cursor/hooks/gtkai-pre-tool-use.sh \
+            scripts/cursor/hooks/gtkai-post-tool-use.sh \
+            scripts/codex/hooks/gtkai-pre-tool-use.sh
+          do
             mode=$(git ls-files -s "$f" | awk '{print $1}')
             if [ "$mode" != "100755" ]; then
               echo "$f is not executable in git (mode: $mode)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,10 @@ jobs:
           echo "Built:"
           ls -lh dist/
 
+          tar -czf dist/gtkai-scripts.tar.gz scripts
+          (cd dist && shasum -a 256 gtkai-scripts.tar.gz > gtkai-scripts.tar.gz.sha256)
+          echo "Packed scripts archive"
+
       - name: Generate SHA256 checksums
         run: |
           cd dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,11 @@
 Two independent phases:
 
 1. **Go binary** (`gtkai`): command proxy and token reduction. PreToolUse rewrites `git status` to `gtkai git status`; the binary runs the real command, injects flags, and filters output.
-2. **Claude Code plugin**: registers hooks (`PreToolUse` for Bash, `PostToolUse` for Read/MCP), templates, and the include in the global `CLAUDE.md`.
+2. **Agent integrations**: Claude Code plugin, Cursor hooks, Codex hooks, and the OpenCode plugin. Each one registers hooks and invokes the binary.
 
-Never collapse both phases into one. The plugin depends on the binary. The binary does not configure Claude Code.
+Never collapse both phases into one. The integrations depend on the binary. The binary does not write agent config files; `install.sh` does.
 
-Target flow and remaining work: `ROADMAP.md`. `0.9.0` completes §3 runners (npm, docker).
+Target flow and remaining work: `ROADMAP.md`. `0.10.0` adds Cursor, Codex, and OpenCode hook integrations. `0.9.0` completed §3 runners (npm, docker).
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,29 @@
 # gtk-ai
 
 ![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?style=flat&logo=go&logoColor=white)
-![Version](https://img.shields.io/badge/version-0.9.0-blue?style=flat)
+![Version](https://img.shields.io/badge/version-0.10.0-blue?style=flat)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat)
-![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin%20compatible-blueviolet?style=flat)
+![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet?style=flat)
+![Cursor](https://img.shields.io/badge/Cursor-hooks-000000?style=flat)
+![Codex](https://img.shields.io/badge/Codex-hooks-412991?style=flat)
+![OpenCode](https://img.shields.io/badge/OpenCode-plugin-6D28D9?style=flat)
 ![Build](https://img.shields.io/badge/build-passing-brightgreen?style=flat)
 
-`gtk-ai` is a two-part integration for Claude Code:
+`gtk-ai` is a two-part integration:
 
-- the `gtkai` Go binary, which rewrites Bash commands before they run and filters their output
-- the Claude plugin, which registers `PreToolUse` and `PostToolUse` hooks and invokes `gtkai`
+- the `gtkai` Go binary, which rewrites shell commands before they run and filters their output
+- per-agent hooks, which register `PreToolUse` / `PostToolUse` (or the agent equivalent) and invoke `gtkai`
 
-Registered Bash commands are rewritten to `gtkai <cmd>` before execution. gtkai runs the real binary, injects compact flags when needed, and filters stdout. `Read` and MCP still go through `PostToolUse`.
+Registered shell commands are rewritten to `gtkai <cmd>` before execution. gtkai runs the real binary, injects compact flags when needed, and filters stdout. On Claude Code and OpenCode, `Read` and MCP still go through post-tool hooks.
 
 ```text
-Claude → Bash("git status")
-              ↓ PreToolUse → gtkai hook-pre
+Agent → Shell("git status")
+              ↓ PreToolUse → gtkai hook-pre --agent=<agent>
          command becomes gtkai git status
               ↓ gtkai runs git status --porcelain -b
          compact grouped status
               ↓
-         Claude receives filtered output
+         Agent receives filtered output
 ```
 
 ## Benchmark
@@ -42,10 +45,7 @@ Savings grow with output size. Small outputs may not be reduced.
 
 ## Installation
 
-gtk-ai requires both parts:
-
-1. the `gtkai` Go binary
-2. the Claude plugin that registers the hook and calls the binary
+gtk-ai requires the `gtkai` binary plus one integration per coding agent. The installer default is `--agent=auto`: it configures every compatible agent it finds on the machine.
 
 ### Option A: install script
 
@@ -53,13 +53,22 @@ gtk-ai requires both parts:
 curl -sSL https://raw.githubusercontent.com/jmeiracorbal/gtk-ai/main/install.sh | sh
 ```
 
-The script installs the binary, registers the marketplace, and prepares the Claude Code integration. When it finishes, run:
+Explicit targets:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/jmeiracorbal/gtk-ai/main/install.sh | sh -s -- --agent=cursor
+curl -sSL https://raw.githubusercontent.com/jmeiracorbal/gtk-ai/main/install.sh | sh -s -- --agent=codex
+curl -sSL https://raw.githubusercontent.com/jmeiracorbal/gtk-ai/main/install.sh | sh -s -- --agent=opencode
+curl -sSL https://raw.githubusercontent.com/jmeiracorbal/gtk-ai/main/install.sh | sh -s -- --agent=all
+```
+
+Claude Code still needs the plugin after the marketplace is registered:
 
 ```bash
 claude plugin install -s user gtk-ai@gtk-ai
 ```
 
-Then restart Claude Code.
+Then restart the agent.
 
 ### Option B: build from source
 
@@ -71,19 +80,22 @@ cd gtk-ai
 go build -o ~/.local/bin/gtkai ./cmd/gtkai/
 ```
 
-Then configure the Claude Code side without reinstalling the binary:
+Then configure agents without reinstalling the binary:
 
 ```bash
-GTKAI_CLAUDE_ONLY=1 sh install.sh
+GTKAI_SKIP_BINARY=1 sh install.sh -- --agent=all
 ```
 
-When it finishes, install the plugin:
+For Claude Code only, `GTKAI_CLAUDE_ONLY=1 sh install.sh` still works and implies `--agent=claudecode`.
 
-```bash
-claude plugin install -s user gtk-ai@gtk-ai
-```
+### Agent surfaces
 
-Restart Claude Code when done.
+| | Claude Code | Cursor | Codex | OpenCode |
+|---|---|---|---|---|
+| **Hooks** | plugin `PreToolUse` / `PostToolUse` | `~/.cursor/hooks/` | `~/.codex/hooks/` | `~/.config/opencode/plugins/gtkai.ts` |
+| **Hook config** | plugin `hooks.json` | `~/.cursor/hooks.json` | `~/.codex/hooks.json` | global plugin |
+| **Shell rewrite** | matcher `Bash` | matcher `Shell` | matcher `Bash` and shell aliases | `tool.execute.before` |
+| **Read / MCP post** | yes | MCP only | shell rewrite only | `read` and MCP tools |
 
 ## Modules
 
@@ -147,12 +159,13 @@ To identify which tools to exempt, check the tool names returned by your MCP ser
 ## Commands
 
 ```text
-gtkai hook-pre      PreToolUse handler — rewrites Bash commands to gtkai
-gtkai hook-post     PostToolUse handler — filters Read and MCP only
-gtkai git status    Proxy: run a registered command through gtkai
-gtkai mcp-scan      List MCP server tools, suggest passthrough prefixes
-gtkai gain          Token savings analytics
-gtkai version       Print version
+gtkai hook-pre --agent=<agent>   PreToolUse handler — rewrites shell commands to gtkai
+gtkai hook-post --agent=<agent>  PostToolUse handler — filters Read and MCP
+gtkai json-merge <file>          Deep-merge JSON from stdin into an agent config file
+gtkai git status                 Proxy: run a registered command through gtkai
+gtkai mcp-scan                   List MCP server tools, suggest passthrough prefixes
+gtkai gain                       Token savings analytics
+gtkai version                    Print version
 ```
 
 ## Architecture
@@ -163,10 +176,11 @@ gtk-ai/
 ├── internal/
 │   ├── registry/           # Module interface + Register() + EstimateTokens()
 │   ├── matchgroup/         # shared grep/rg grouping
-│   ├── shell/              # Bash command rewrite
+│   ├── shell/              # shell command rewrite
 │   ├── proxy/              # execute + filter + gain
 │   ├── text/               # ANSI strip
-│   └── hook/               # PreToolUse and PostToolUse handlers
+│   ├── jsonmerge/          # installer config merge
+│   └── hook/               # PreToolUse and PostToolUse handlers (per-agent JSON)
 ├── modules/
 │   ├── find/               # find output filter
 │   ├── ls/                 # ls output filter
@@ -175,9 +189,11 @@ gtk-ai/
 │   ├── readcmd/            # cat/head/tail via read.FilterContent
 │   ├── tree/               # tree output filter
 │   └── gain/               # SQLite token savings analytics
-└── plugin/
-    ├── hooks/              # Claude plugin hook registration
-    └── scripts/            # scripts that invoke gtkai from Claude's hook system
+├── plugin/                 # Claude Code plugin (hooks + scripts)
+└── scripts/
+    ├── cursor/             # Cursor hook scripts + rule
+    ├── codex/              # Codex hook scripts
+    └── opencode/           # OpenCode plugin
 ```
 
 The `registry` package is the only shared dependency between modules. Modules never import each other.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap: gtk-ai vs rtk 0.42.4
 
-Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.9.0`.
+Compared against [rtk-ai/rtk](https://github.com/rtk-ai/rtk) `0.42.4` (`ba7a9ce`). gtk-ai is at `0.10.0`.
 
 **Product decision (2026-08-17):** gtk follows the same path as rtk. It rewrites the command **before** execution (`PreToolUse` → `git status` becomes `gtkai git status`). gtkai runs the real binary, injects flags, and filters the output. Post-filtering remains only for Claude Code native tools that do not go through Bash (`Read`, MCP, `Grep`, `Glob`).
 
@@ -207,8 +207,9 @@ Done when: native `gtkai/gtkai-*` filters use the same registry; install/uninsta
 
 ## Current vs target
 
-| | gtk-ai 0.9.0 | Remaining |
+| | gtk-ai 0.10.0 | Remaining |
 |---|---|---|
+| Agents | Claude Code plugin; Cursor / Codex hooks; OpenCode plugin | — |
 | Bash | `PreToolUse` rewrites registered commands to `gtkai …`; the binary runs and filters | Bash removed from `PostToolUse` (0.5.0) |
 | Filter identity | Flat `registry.Get("ls")` | Namespaced `author/gtkai-<command>`; active = most recent install |
 | `Rewrite()` | Injects flags for `git status`, `git log`, `ls`, `grep`, `go test -json` | Runners (cargo, pytest, …); third-party filters via `filter install` |
@@ -237,7 +238,8 @@ Filtering stays heuristic. No semantic compression.
 1. PreToolUse proxy + end-to-end `git status` (section 1) — **done in 0.4.0**.
 2. Corrections to current modules + `cat`/`head`/`tail`/`tree` + remaining git (section 2) — **done in 0.5.0**.
 3. Runners (section 3) — **done in 0.9.0** (go, cargo, pytest, npm, docker).
-4. Filter plugin registry + install/uninstall/list + migrate natives to `gtkai/gtkai-*` (section 4).
-5. Ecosystem commands as third-party filters according to `gain` (section 3 ecosystem).
+4. Multi-agent hooks (Cursor, Codex, OpenCode) — **done in 0.10.0**.
+5. Filter plugin registry + install/uninstall/list + migrate natives to `gtkai/gtkai-*` (section 4).
+6. Ecosystem commands as third-party filters according to `gain` (section 3 ecosystem).
 
 The git tag must match every version-bearing file (`cmd/gtkai/main.go`, plugin json, `mcpscan`, README).

--- a/cmd/gtkai/assets_test.go
+++ b/cmd/gtkai/assets_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShippedAgentAssets(t *testing.T) {
+	root := filepath.Join("..", "..")
+	files := []string{
+		"plugin/scripts/gtkai-pre-tool-use.sh",
+		"plugin/scripts/gtkai-post-tool-use.sh",
+		"plugin/hooks/hooks.json",
+		"scripts/claudecode/gtk-ai.md",
+		"scripts/cursor/hooks/gtkai-pre-tool-use.sh",
+		"scripts/cursor/hooks/gtkai-post-tool-use.sh",
+		"scripts/cursor/rules/gtk-ai.mdc",
+		"scripts/codex/hooks/gtkai-pre-tool-use.sh",
+		"scripts/codex/AGENTS.md",
+		"scripts/opencode/plugins/gtkai.ts",
+		"scripts/opencode/AGENTS.md",
+	}
+	for _, rel := range files {
+		path := filepath.Join(root, rel)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("missing shipped file %s: %v", rel, err)
+		}
+	}
+}
+
+func TestClaudePluginScriptsPassAgent(t *testing.T) {
+	root := filepath.Join("..", "..")
+	pre, err := os.ReadFile(filepath.Join(root, "plugin/scripts/gtkai-pre-tool-use.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(pre), "hook-pre --agent=claudecode") {
+		t.Fatal("claude pre script must pass --agent=claudecode")
+	}
+	post, err := os.ReadFile(filepath.Join(root, "plugin/scripts/gtkai-post-tool-use.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(post), "hook-post --agent=claudecode") {
+		t.Fatal("claude post script must pass --agent=claudecode")
+	}
+}
+
+func TestCursorAndCodexScriptsPassAgent(t *testing.T) {
+	root := filepath.Join("..", "..")
+	cases := []struct {
+		path   string
+		needle string
+	}{
+		{"scripts/cursor/hooks/gtkai-pre-tool-use.sh", "hook-pre --agent=cursor"},
+		{"scripts/cursor/hooks/gtkai-post-tool-use.sh", "hook-post --agent=cursor"},
+		{"scripts/codex/hooks/gtkai-pre-tool-use.sh", "hook-pre --agent=codex"},
+	}
+	for _, tc := range cases {
+		data, err := os.ReadFile(filepath.Join(root, tc.path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(data), tc.needle) {
+			t.Errorf("%s: missing %q", tc.path, tc.needle)
+		}
+	}
+}

--- a/cmd/gtkai/flags_test.go
+++ b/cmd/gtkai/flags_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestParseAgentFlag(t *testing.T) {
+	got, err := parseAgentFlag([]string{"--agent=cursor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "cursor" {
+		t.Fatalf("got %q", got)
+	}
+
+	got, err = parseAgentFlag([]string{"--agent", "codex"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "codex" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParseAgentFlagRequired(t *testing.T) {
+	if _, err := parseAgentFlag(nil); err == nil {
+		t.Fatal("missing --agent must fail")
+	}
+	if _, err := parseAgentFlag([]string{"--agent"}); err == nil {
+		t.Fatal("bare --agent must fail")
+	}
+	if _, err := parseAgentFlag([]string{"--agent="}); err == nil {
+		t.Fatal("empty --agent value must fail")
+	}
+	if _, err := parseAgentFlag([]string{"--agent=windsurf"}); err == nil {
+		t.Fatal("unknown agent must fail")
+	}
+	if _, err := parseAgentFlag([]string{"--agent=cursor", "--extra"}); err == nil {
+		t.Fatal("unknown extra argument must fail")
+	}
+}

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -1,24 +1,26 @@
-// gtk-ai — PreToolUse proxy and PostToolUse filter for Claude Code.
+// gtk-ai — PreToolUse proxy and PostToolUse filter for coding agents.
 // Binary: gtkai
 package main
 
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jmeiracorbal/gtk-ai/internal/hook"
+	"github.com/jmeiracorbal/gtk-ai/internal/jsonmerge"
 	"github.com/jmeiracorbal/gtk-ai/internal/proxy"
 	"github.com/jmeiracorbal/gtk-ai/internal/registry"
 	"github.com/jmeiracorbal/gtk-ai/modules/gain"
 	"github.com/jmeiracorbal/gtk-ai/modules/mcpscan"
 
 	_ "github.com/jmeiracorbal/gtk-ai/modules/cargo"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/docker"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/find"
-	_ "github.com/jmeiracorbal/gtk-ai/modules/go"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/git"
+	_ "github.com/jmeiracorbal/gtk-ai/modules/go"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/grep"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/ls"
-	_ "github.com/jmeiracorbal/gtk-ai/modules/docker"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/npmtest"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/pytest"
 	_ "github.com/jmeiracorbal/gtk-ai/modules/python"
@@ -27,18 +29,22 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
 
-const version = "0.9.0"
+const version = "0.10.0"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s
 
 Usage:
-  gtkai hook-pre             PreToolUse hook — rewrites Bash commands to gtkai
-  gtkai hook-post            PostToolUse hook — reads stdin, writes filtered output
-  gtkai <module> [args...]   Run a registered command through the proxy
-  gtkai mcp-scan             List tools from all MCP servers, suggest passthrough prefixes
-  gtkai gain                 Show token savings analytics
-  gtkai version              Print version
+  gtkai hook-pre --agent=<agent>   PreToolUse hook — rewrites shell commands to gtkai
+  gtkai hook-post --agent=<agent>  PostToolUse hook — reads stdin, writes filtered output
+  gtkai json-merge <file>          Deep-merge JSON from stdin into <file>
+  gtkai <module> [args...]         Run a registered command through the proxy
+  gtkai mcp-scan                   List tools from all MCP servers, suggest passthrough prefixes
+  gtkai gain                       Show token savings analytics
+  gtkai version                    Print version
+
+Agents:
+  claudecode, cursor, codex, opencode
 
 Environment:
   GTK_MCP_PASSTHROUGH_PATTERNS  Comma-separated MCP tool patterns to skip filtering
@@ -57,22 +63,48 @@ func main() {
 		fmt.Printf("gtkai %s\n", version)
 
 	case "hook-pre":
+		agent, err := parseAgentFlag(os.Args[2:])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gtkai hook-pre: %v\n", err)
+			os.Exit(1)
+		}
 		bin, err := os.Executable()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "gtkai hook-pre: %v\n", err)
 			os.Exit(1)
 		}
-		_, err = hook.RunPre(os.Stdin, os.Stdout, bin)
+		_, err = hook.RunPre(os.Stdin, os.Stdout, bin, agent)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "gtkai hook-pre: %v\n", err)
 			os.Exit(1)
 		}
 
 	case "hook-post":
-		_, err := hook.Run(os.Stdin, os.Stdout)
+		agent, err := parseAgentFlag(os.Args[2:])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "gtkai hook-post: %v\n", err)
 			os.Exit(1)
+		}
+		_, err = hook.Run(os.Stdin, os.Stdout, agent)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gtkai hook-post: %v\n", err)
+			os.Exit(1)
+		}
+
+	case "json-merge":
+		if len(os.Args) != 3 || os.Args[2] == "" {
+			fmt.Fprintln(os.Stderr, "usage: gtkai json-merge <file>")
+			os.Exit(1)
+		}
+		changed, err := jsonmerge.MergeFile(os.Args[2])
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gtkai json-merge: %v\n", err)
+			os.Exit(1)
+		}
+		if changed {
+			fmt.Println("updated")
+		} else {
+			fmt.Println("unchanged")
 		}
 
 	case "mcp-scan":
@@ -101,4 +133,38 @@ func main() {
 		}
 		os.Exit(proxy.Run(os.Args[1], os.Args[2:]))
 	}
+}
+
+func parseAgentFlag(args []string) (hook.Agent, error) {
+	var agent hook.Agent
+	seen := false
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--agent":
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("--agent requires a value")
+			}
+			parsed, err := hook.ParseAgent(args[i+1])
+			if err != nil {
+				return "", err
+			}
+			agent = parsed
+			seen = true
+			i++
+		case strings.HasPrefix(a, "--agent="):
+			parsed, err := hook.ParseAgent(strings.TrimPrefix(a, "--agent="))
+			if err != nil {
+				return "", err
+			}
+			agent = parsed
+			seen = true
+		default:
+			return "", fmt.Errorf("unknown argument %q", a)
+		}
+	}
+	if !seen {
+		return "", fmt.Errorf("--agent is required")
+	}
+	return agent, nil
 }

--- a/install.sh
+++ b/install.sh
@@ -2,18 +2,38 @@
 # gtk-ai installer
 # Usage: curl -sSL https://raw.githubusercontent.com/jmeiracorbal/gtk-ai/main/install.sh | sh
 #
-# To configure only the Claude Code side (skip binary install):
+# Agent selection (default: auto-detect installed compatible agents):
+#   sh -s -- --agent=auto
+#   sh -s -- --agent=claudecode
+#   sh -s -- --agent=cursor
+#   sh -s -- --agent=codex
+#   sh -s -- --agent=opencode
+#   sh -s -- --agent=all
+#
+# To skip binary install (configure agents only):
 #   GTKAI_CLAUDE_ONLY=1 sh install.sh
+#   GTKAI_SKIP_BINARY=1 sh install.sh -- --agent=cursor
+#
+# Environment:
+#   GTKAI_AGENT=cursor
+#   GTKAI_SCRIPTS_DIR=/path/to/scripts
+#   GTKAI_INSTALL_DIR=$HOME/.local/bin
+#   GTKAI_DRY_RUN=true
 
 set -e
 
 REPO="jmeiracorbal/gtk-ai"
 BINARY="gtkai"
 INSTALL_DIR="${GTKAI_INSTALL_DIR:-$HOME/.local/bin}"
-CLAUDE_ONLY="${GTKAI_CLAUDE_ONLY:-}"
+SKIP_BINARY="${GTKAI_SKIP_BINARY:-${GTKAI_CLAUDE_ONLY:-}}"
+DRY_RUN="${GTKAI_DRY_RUN:-false}"
+AGENT="${GTKAI_AGENT:-auto}"
+if [ -n "${GTKAI_CLAUDE_ONLY:-}" ] && [ -z "${GTKAI_AGENT:-}" ]; then
+  AGENT=claudecode
+fi
 TMP_DIR=$(mktemp -d)
-
-# ── Colours ───────────────────────────────────────────────────────────────────
+TMP_SCRIPTS=""
+GTKAI_BIN=""
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -28,15 +48,11 @@ warn()    { printf "${YELLOW}  ⚠${RESET} %s\n" "$1"; }
 error()   { printf "${RED}  ✗${RESET} %s\n" "$1" >&2; exit 1; }
 header()  { printf "\n${BOLD}%s${RESET}\n" "$1"; }
 
-# ── Banner ────────────────────────────────────────────────────────────────────
-
 printf "${BOLD}"
 cat <<'EOF'
-   gtk-ai — rule-based output filtering for Claude Code
+   gtk-ai — rule-based output filtering for coding agents
 EOF
 printf "${RESET}\n"
-
-# ── Detect OS and architecture ────────────────────────────────────────────────
 
 header "Detecting system"
 
@@ -58,22 +74,16 @@ esac
 info "OS:   $OS"
 info "Arch: $ARCH"
 
-# ── Detect tools ──────────────────────────────────────────────────────────────
-
 header "Checking dependencies"
 
 HAS_GO=false
 HAS_CURL=false
 HAS_WGET=false
-HAS_JQ=false
 
 command -v go    >/dev/null 2>&1 && HAS_GO=true   && success "Go found: $(go version | awk '{print $3}')"
 command -v curl  >/dev/null 2>&1 && HAS_CURL=true && success "curl found"
 command -v wget  >/dev/null 2>&1 && HAS_WGET=true
 command -v git   >/dev/null 2>&1 || error "git is required. Install it and retry."
-command -v jq    >/dev/null 2>&1 && HAS_JQ=true   || warn "jq not found — marketplace JSON update will be skipped"
-
-# ── Download helpers ──────────────────────────────────────────────────────────
 
 fetch() {
   url="$1"
@@ -98,37 +108,60 @@ fetch_stdout() {
   fi
 }
 
-# ── jq helpers ────────────────────────────────────────────────────────────────
-
-# Run jq and write output atomically; fails hard if jq errors.
-# Usage: jq_update [jq-options...] filter file
-# All arguments are passed to jq; the last argument is the file updated in place.
-jq_update() {
-  eval "file=\${$#}"
-  tmp=$(mktemp)
-  if ! jq "$@" > "$tmp"; then
-    rm -f "$tmp"
-    error "jq failed updating $file"
+probe_url() {
+  url="$1"
+  if $HAS_CURL; then
+    curl -sSfI "$url" >/dev/null 2>&1
+  elif $HAS_WGET; then
+    wget -q --spider "$url" >/dev/null 2>&1
+  else
+    return 1
   fi
-  mv "$tmp" "$file"
 }
 
+json_merge() {
+  patch="$1"
+  file="$2"
+  printf '%s' "$patch" | "$GTKAI_BIN" json-merge "$file"
+}
 
-# ── Install binary ────────────────────────────────────────────────────────────
-
-if [ -n "$CLAUDE_ONLY" ]; then
-  header "Skipping binary install (GTKAI_CLAUDE_ONLY=1)"
-
-  if ! command -v "$BINARY" >/dev/null 2>&1 && ! [ -x "$INSTALL_DIR/$BINARY" ]; then
-    error "$BINARY not found. Install it first or unset GTKAI_CLAUDE_ONLY."
+append_marked_block() {
+  dest="$1"
+  src="$2"
+  start="<!-- gtk-ai:start -->"
+  end="<!-- gtk-ai:end -->"
+  mkdir -p "$(dirname "$dest")"
+  if [ -f "$dest" ] && grep -qF "$start" "$dest"; then
+    info "$dest — gtk-ai block already present"
+    return
   fi
+  {
+    [ -f "$dest" ] && cat "$dest"
+    printf '\n%s\n' "$start"
+    cat "$src"
+    printf '%s\n' "$end"
+  } > "$dest.tmp"
+  mv "$dest.tmp" "$dest"
+  success "$dest updated"
+}
 
+resolve_binary() {
   if [ -x "$INSTALL_DIR/$BINARY" ]; then
-    INSTALLED_VERSION=$("$INSTALL_DIR/$BINARY" version | awk '{print $2}')
-  else
-    INSTALLED_VERSION=$(gtkai version | awk '{print $2}')
+    GTKAI_BIN="$INSTALL_DIR/$BINARY"
+    return
   fi
-  success "$BINARY $INSTALLED_VERSION found"
+  if command -v "$BINARY" >/dev/null 2>&1; then
+    GTKAI_BIN=$(command -v "$BINARY")
+    return
+  fi
+  error "$BINARY not found. Install it first or unset GTKAI_SKIP_BINARY."
+}
+
+if [ -n "$SKIP_BINARY" ]; then
+  header "Skipping binary install (GTKAI_SKIP_BINARY/GTKAI_CLAUDE_ONLY)"
+  resolve_binary
+  INSTALLED_VERSION=$("$GTKAI_BIN" version | awk '{print $2}')
+  success "$BINARY $INSTALLED_VERSION found ($GTKAI_BIN)"
 else
   header "Installing $BINARY"
 
@@ -190,17 +223,19 @@ else
       go build -o "$INSTALL_DIR/$BINARY" ./cmd/gtkai/
       cd - >/dev/null
       success "Built from source"
+      if [ -d "$TMP_DIR/gtk-ai/scripts/cursor/hooks" ]; then
+        TMP_SCRIPTS="$TMP_DIR/gtk-ai/scripts"
+      fi
     fi
   fi
 
-  if ! "$INSTALL_DIR/$BINARY" version >/dev/null 2>&1; then
-    error "Binary installed but failed to run. Check $INSTALL_DIR/$BINARY"
+  GTKAI_BIN="$INSTALL_DIR/$BINARY"
+  if ! "$GTKAI_BIN" version >/dev/null 2>&1; then
+    error "Binary installed but failed to run. Check $GTKAI_BIN"
   fi
 
-  INSTALLED_VERSION=$("$INSTALL_DIR/$BINARY" version | awk '{print $2}')
-  success "$BINARY $INSTALLED_VERSION installed to $INSTALL_DIR/$BINARY"
-
-  # ── Add to PATH ──────────────────────────────────────────────────────────────
+  INSTALLED_VERSION=$("$GTKAI_BIN" version | awk '{print $2}')
+  success "$BINARY $INSTALLED_VERSION installed to $GTKAI_BIN"
 
   header "Configuring PATH"
 
@@ -225,128 +260,265 @@ else
   export PATH="$INSTALL_DIR:$PATH"
 fi
 
-# ── Claude Code setup ─────────────────────────────────────────────────────────
-
-header "Configuring Claude Code"
-
-CLAUDE_DIR="$HOME/.claude"
-SETTINGS_FILE="$CLAUDE_DIR/settings.json"
-KNOWN_MARKETPLACES="$CLAUDE_DIR/plugins/known_marketplaces.json"
-MARKETPLACE_DIR="$CLAUDE_DIR/plugins/marketplaces/gtk-ai"
-PROTOCOL_DOC="$CLAUDE_DIR/gtk-ai.md"
-CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
-
-mkdir -p "$CLAUDE_DIR/plugins/marketplaces"
-
-# Register marketplace in settings.json
-if [ -f "$SETTINGS_FILE" ] && $HAS_JQ; then
-  if jq -e '.extraKnownMarketplaces["gtk-ai"]' "$SETTINGS_FILE" >/dev/null 2>&1; then
-    info "$HOME/.claude/settings.json — marketplace gtk-ai already registered"
-  else
-    jq_update '.extraKnownMarketplaces["gtk-ai"] = {"source": {"source": "github", "repo": "jmeiracorbal/gtk-ai"}}' "$SETTINGS_FILE"
-    success "$HOME/.claude/settings.json — marketplace gtk-ai registered"
+resolve_scripts() {
+  if [ -n "$TMP_SCRIPTS" ]; then
+    return
   fi
-elif [ ! -f "$SETTINGS_FILE" ]; then
-  jq_create '{
-  "extraKnownMarketplaces": {
-    "gtk-ai": {
-      "source": {
-        "source": "github",
-        "repo": "jmeiracorbal/gtk-ai"
-      }
-    }
-  }
-}' "$SETTINGS_FILE"
-  success "$HOME/.claude/settings.json — created with marketplace gtk-ai"
-else
-  warn "jq not found — skipping settings.json update. Add the marketplace manually."
+  if [ -n "${GTKAI_SCRIPTS_DIR:-}" ]; then
+    TMP_SCRIPTS="$GTKAI_SCRIPTS_DIR"
+    return
+  fi
+  if [ -f "$0" ] && [ -d "$(dirname "$0")/scripts/cursor/hooks" ]; then
+    TMP_SCRIPTS="$(cd "$(dirname "$0")" && pwd)/scripts"
+    return
+  fi
+
+  header "Fetching agent scripts"
+  archive_url="https://github.com/$REPO/releases/latest/download/gtkai-scripts.tar.gz"
+  checksum_url="https://github.com/$REPO/releases/latest/download/gtkai-scripts.tar.gz.sha256"
+  if probe_url "$archive_url"; then
+    tmp_archive=$(mktemp)
+    fetch "$archive_url" "$tmp_archive" || error "Scripts archive download failed"
+    expected=$(fetch_stdout "$checksum_url" | awk '{print $1}')
+    if [ -z "$expected" ]; then
+      error "Could not fetch scripts checksum"
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+      actual=$(shasum -a 256 "$tmp_archive" | awk '{print $1}')
+    else
+      actual=$(sha256sum "$tmp_archive" | awk '{print $1}')
+    fi
+    if [ "$actual" != "$expected" ]; then
+      error "Scripts checksum mismatch. Expected: $expected  Got: $actual"
+    fi
+    TMP_SCRIPTS=$(mktemp -d)
+    tar -xzf "$tmp_archive" -C "$TMP_SCRIPTS" --strip-components=1
+    rm -f "$tmp_archive"
+    success "Scripts ready"
+    return
+  fi
+
+  info "No scripts archive in the latest release — cloning repository"
+  git clone --depth 1 "https://github.com/$REPO.git" "$TMP_DIR/gtk-ai-scripts" >/dev/null 2>&1
+  TMP_SCRIPTS="$TMP_DIR/gtk-ai-scripts/scripts"
+}
+
+setup_claudecode() {
+  header "Configuring Claude Code"
+
+  CLAUDE_DIR="$HOME/.claude"
+  SETTINGS_FILE="$CLAUDE_DIR/settings.json"
+  KNOWN_MARKETPLACES="$CLAUDE_DIR/plugins/known_marketplaces.json"
+  MARKETPLACE_DIR="$CLAUDE_DIR/plugins/marketplaces/gtk-ai"
+  PROTOCOL_DOC="$CLAUDE_DIR/gtk-ai.md"
+  CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
+
+  mkdir -p "$CLAUDE_DIR/plugins/marketplaces"
+
+  result=$(json_merge '{"extraKnownMarketplaces":{"gtk-ai":{"source":{"source":"github","repo":"jmeiracorbal/gtk-ai"}}}}' "$SETTINGS_FILE")
+  success "$HOME/.claude/settings.json — $result"
+
+  if [ -d "$MARKETPLACE_DIR/.git" ]; then
+    info "Marketplace cache exists — updating..."
+    git -C "$MARKETPLACE_DIR" pull --ff-only -q 2>/dev/null || warn "Could not update marketplace cache"
+    if git -C "$MARKETPLACE_DIR" checkout "v$INSTALLED_VERSION" -q 2>/dev/null; then
+      success "$HOME/.claude/plugins/marketplaces/gtk-ai pinned to v$INSTALLED_VERSION"
+    else
+      warn "Tag v$INSTALLED_VERSION not found — using default branch"
+    fi
+  else
+    info "Cloning marketplace cache..."
+    if git clone --depth 1 --branch "v$INSTALLED_VERSION" "https://github.com/$REPO.git" "$MARKETPLACE_DIR" >/dev/null 2>&1; then
+      success "$HOME/.claude/plugins/marketplaces/gtk-ai cloned at v$INSTALLED_VERSION"
+    elif git clone --depth 1 "https://github.com/$REPO.git" "$MARKETPLACE_DIR" >/dev/null 2>&1; then
+      warn "Tag v$INSTALLED_VERSION not found — using default branch"
+    else
+      error "Failed to clone marketplace repository"
+    fi
+  fi
+
+  NOW=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+  result=$(json_merge "$(printf '{"gtk-ai":{"source":{"source":"github","repo":"jmeiracorbal/gtk-ai"},"installLocation":"%s","lastUpdated":"%s"}}' "$MARKETPLACE_DIR" "$NOW")" "$KNOWN_MARKETPLACES")
+  success "$HOME/.claude/plugins/known_marketplaces.json — $result"
+
+  cp "$TMP_SCRIPTS/claudecode/gtk-ai.md" "$PROTOCOL_DOC"
+  success "$HOME/.claude/gtk-ai.md written"
+
+  if [ -f "$CLAUDE_MD" ]; then
+    if grep -q "@gtk-ai.md" "$CLAUDE_MD" 2>/dev/null; then
+      info "$HOME/.claude/CLAUDE.md — already up to date"
+    else
+      printf '\n@gtk-ai.md\n' >> "$CLAUDE_MD"
+      success "$HOME/.claude/CLAUDE.md updated"
+    fi
+  else
+    printf '@gtk-ai.md\n' > "$CLAUDE_MD"
+    success "$HOME/.claude/CLAUDE.md created"
+  fi
+
+  printf "To activate the Claude plugin, run:\n\n"
+  printf "  ${BOLD}%s${RESET}\n\n" "claude plugin install -s user gtk-ai@gtk-ai"
+  printf "Then restart Claude Code.\n"
+}
+
+setup_cursor() {
+  header "Configuring Cursor"
+
+  hooks_dir="$HOME/.cursor/hooks"
+  hooks_json="$HOME/.cursor/hooks.json"
+  rules_dir="$HOME/.cursor/rules"
+
+  mkdir -p "$hooks_dir" "$rules_dir"
+  cp "$TMP_SCRIPTS/cursor/hooks/gtkai-pre-tool-use.sh" "$hooks_dir/"
+  cp "$TMP_SCRIPTS/cursor/hooks/gtkai-post-tool-use.sh" "$hooks_dir/"
+  chmod +x "$hooks_dir/gtkai-pre-tool-use.sh" "$hooks_dir/gtkai-post-tool-use.sh"
+  success "Hook scripts installed to ${hooks_dir}"
+
+  patch=$(printf '{"version":1,"hooks":{"preToolUse":[{"command":"%s/gtkai-pre-tool-use.sh","matcher":"Shell"}],"postToolUse":[{"command":"%s/gtkai-post-tool-use.sh","matcher":"MCP:.*"}]}}' "$hooks_dir" "$hooks_dir")
+  result=$(json_merge "$patch" "$hooks_json")
+  success "$HOME/.cursor/hooks.json — $result"
+
+  cp "$TMP_SCRIPTS/cursor/rules/gtk-ai.mdc" "$rules_dir/gtk-ai.mdc"
+  success "$HOME/.cursor/rules/gtk-ai.mdc written"
+}
+
+setup_codex() {
+  header "Configuring Codex"
+
+  hooks_dir="$HOME/.codex/hooks"
+  hooks_json="$HOME/.codex/hooks.json"
+  codex_config="$HOME/.codex/config.toml"
+  agents_md="$HOME/.codex/AGENTS.md"
+
+  mkdir -p "$hooks_dir"
+  cp "$TMP_SCRIPTS/codex/hooks/gtkai-pre-tool-use.sh" "$hooks_dir/"
+  chmod +x "$hooks_dir/gtkai-pre-tool-use.sh"
+  success "Hook scripts installed to ${hooks_dir}"
+
+  patch=$(printf '{"hooks":{"PreToolUse":[{"matcher":"Bash|shell|local_shell|container_exec|exec_command|shell_command","hooks":[{"type":"command","command":"%s/gtkai-pre-tool-use.sh","statusMessage":"gtkai rewrite","timeout":10}]}]}}' "$hooks_dir")
+  result=$(json_merge "$patch" "$hooks_json")
+  success "$HOME/.codex/hooks.json — $result"
+
+  mkdir -p "$HOME/.codex"
+  touch "$codex_config"
+  if grep -q 'codex_hooks' "$codex_config" 2>/dev/null; then
+    info "$HOME/.codex/config.toml — codex_hooks already set"
+  elif grep -q '^\[features\]' "$codex_config" 2>/dev/null; then
+    tmp_cfg=$(mktemp)
+    awk '/^\[features\]/{print; print "codex_hooks = true"; next} {print}' "$codex_config" > "$tmp_cfg"
+    mv "$tmp_cfg" "$codex_config"
+    success "$HOME/.codex/config.toml — enabled [features].codex_hooks"
+  else
+    tail -c1 "$codex_config" 2>/dev/null | grep -q $'\n' || printf '\n' >> "$codex_config"
+    printf '\n[features]\ncodex_hooks = true\n' >> "$codex_config"
+    success "$HOME/.codex/config.toml — enabled [features].codex_hooks"
+  fi
+
+  append_marked_block "$agents_md" "$TMP_SCRIPTS/codex/AGENTS.md"
+}
+
+setup_opencode() {
+  header "Configuring OpenCode"
+
+  plugins_dir="$HOME/.config/opencode/plugins"
+  agents_md="$HOME/.config/opencode/AGENTS.md"
+
+  mkdir -p "$plugins_dir"
+  cp "$TMP_SCRIPTS/opencode/plugins/gtkai.ts" "$plugins_dir/"
+  success "Plugin installed to ${plugins_dir}"
+
+  append_marked_block "$agents_md" "$TMP_SCRIPTS/opencode/AGENTS.md"
+}
+
+agent_detected() {
+  case "$1" in
+    claudecode)
+      command -v claude >/dev/null 2>&1 || [ -d "$HOME/.claude" ] || [ -f "$HOME/.claude.json" ]
+      ;;
+    cursor)
+      command -v cursor >/dev/null 2>&1 || [ -d "$HOME/.cursor" ]
+      ;;
+    codex)
+      command -v codex >/dev/null 2>&1 || [ -d "$HOME/.codex" ]
+      ;;
+    opencode)
+      command -v opencode >/dev/null 2>&1 || [ -d "$HOME/.config/opencode" ]
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+detect_agents() {
+  found=""
+  for agent in claudecode cursor codex opencode; do
+    if agent_detected "$agent"; then
+      found="$found $agent"
+    fi
+  done
+  printf '%s' "$found"
+}
+
+setup_agent() {
+  agent="$1"
+  case "$agent" in
+    claudecode) setup_claudecode ;;
+    cursor) setup_cursor ;;
+    codex) setup_codex ;;
+    opencode) setup_opencode ;;
+    *) error "Unknown agent: ${agent}. Valid options: auto | claudecode | cursor | codex | opencode | all" ;;
+  esac
+}
+
+warn_rtk() {
+  if command -v rtk >/dev/null 2>&1; then
+    warn "RTK is installed. To avoid conflicts, remove its hooks from agent settings"
+    warn "Look for entries referencing rtk-rewrite.sh or rtk-post-tool-use.sh"
+  fi
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --agent=*) AGENT="${arg#--agent=}" ;;
+  esac
+done
+
+if [ "$DRY_RUN" = "true" ]; then
+  info "Dry-run mode — no agent files will be written"
+  info "Would configure agent=${AGENT}"
+  success "Done (dry-run)."
+  rm -rf "$TMP_DIR"
+  exit 0
 fi
 
-# Clone marketplace repo to local cache, pinned to installed version
-if [ -d "$MARKETPLACE_DIR/.git" ]; then
-  info "Marketplace cache exists — updating..."
-  git -C "$MARKETPLACE_DIR" pull --ff-only -q 2>/dev/null || warn "Could not update marketplace cache"
-  if git -C "$MARKETPLACE_DIR" checkout "v$INSTALLED_VERSION" -q 2>/dev/null; then
-    success "$HOME/.claude/plugins/marketplaces/gtk-ai pinned to v$INSTALLED_VERSION"
-  else
-    warn "Tag v$INSTALLED_VERSION not found — using default branch"
-  fi
-else
-  info "Cloning marketplace cache..."
-  if git clone --depth 1 --branch "v$INSTALLED_VERSION" "https://github.com/$REPO.git" "$MARKETPLACE_DIR" >/dev/null 2>&1; then
-    success "$HOME/.claude/plugins/marketplaces/gtk-ai cloned at v$INSTALLED_VERSION"
-  elif git clone --depth 1 "https://github.com/$REPO.git" "$MARKETPLACE_DIR" >/dev/null 2>&1; then
-    warn "Tag v$INSTALLED_VERSION not found — using default branch"
-  else
-    error "Failed to clone marketplace repository"
-  fi
-fi
+resolve_scripts
 
-# Register in known_marketplaces.json
-NOW=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-if [ -f "$KNOWN_MARKETPLACES" ] && $HAS_JQ; then
-  if jq -e '.["gtk-ai"]' "$KNOWN_MARKETPLACES" >/dev/null 2>&1; then
-    info "$HOME/.claude/plugins/known_marketplaces.json — gtk-ai already indexed"
-  else
-    jq_update \
-      --arg loc "$MARKETPLACE_DIR" --arg now "$NOW" \
-      '.["gtk-ai"] = {"source": {"source": "github", "repo": "jmeiracorbal/gtk-ai"}, "installLocation": $loc, "lastUpdated": $now}' \
-      "$KNOWN_MARKETPLACES"
-    success "$HOME/.claude/plugins/known_marketplaces.json — gtk-ai indexed"
-  fi
-elif ! [ -f "$KNOWN_MARKETPLACES" ]; then
-  jq -n --arg loc "$MARKETPLACE_DIR" --arg now "$NOW" \
-    '{"gtk-ai": {"source": {"source": "github", "repo": "jmeiracorbal/gtk-ai"}, "installLocation": $loc, "lastUpdated": $now}}' \
-    > "$KNOWN_MARKETPLACES"
-  success "$HOME/.claude/plugins/known_marketplaces.json — created with gtk-ai"
-else
-  warn "jq not found — skipping known_marketplaces.json update."
-fi
+case "$AGENT" in
+  auto)
+    detected=$(detect_agents)
+    if [ -z "$detected" ]; then
+      error "No compatible agent detected. Pass --agent=claudecode|cursor|codex|opencode|all"
+    fi
+    info "Auto-detected agents:${detected}"
+    for selected in $detected; do
+      setup_agent "$selected"
+    done
+    ;;
+  all)
+    for selected in claudecode cursor codex opencode; do
+      setup_agent "$selected"
+    done
+    ;;
+  claudecode|cursor|codex|opencode)
+    setup_agent "$AGENT"
+    ;;
+  *)
+    error "Unknown agent: ${AGENT}. Valid options: auto | claudecode | cursor | codex | opencode | all"
+    ;;
+esac
 
-# Write context doc (note: hook becomes active only after plugin install)
-cat > "$PROTOCOL_DOC" <<'PROTOCOL'
-## gtk-ai — rule-based output filtering
-
-gtk-ai filters Bash, grep, find, ls, git, and MCP tool output before it enters
-the context. Depending on the command, it applies truncation, extension grouping,
-condensed formatting, or comment line removal.
-
-The hook is active only when the Claude plugin is installed and enabled.
-Run `claude plugin install -s user gtk-ai@gtk-ai` if you have not done so.
-PROTOCOL
-success "$HOME/.claude/gtk-ai.md written"
-
-# Inject @gtk-ai.md into CLAUDE.md
-if [ -f "$CLAUDE_MD" ]; then
-  if grep -q "@gtk-ai.md" "$CLAUDE_MD" 2>/dev/null; then
-    info "$HOME/.claude/CLAUDE.md — already up to date"
-  else
-    printf '\n@gtk-ai.md\n' >> "$CLAUDE_MD"
-    success "$HOME/.claude/CLAUDE.md updated"
-  fi
-else
-  printf '@gtk-ai.md\n' > "$CLAUDE_MD"
-  success "$HOME/.claude/CLAUDE.md created"
-fi
-
-# ── RTK warning ───────────────────────────────────────────────────────────────
-
-if command -v rtk >/dev/null 2>&1; then
-  warn "RTK is installed. To avoid conflicts, remove its hooks from ~/.claude/settings.json"
-  warn "Look for entries referencing rtk-rewrite.sh or rtk-post-tool-use.sh"
-fi
-
-# ── Cleanup ───────────────────────────────────────────────────────────────────
-
+warn_rtk
 rm -rf "$TMP_DIR"
 
-# ── Done ──────────────────────────────────────────────────────────────────────
-
-if [ -n "$CLAUDE_ONLY" ]; then
-  printf "\n${BOLD}${GREEN}%s${RESET}\n\n" "Claude configuration completed."
-else
-  printf "\n${BOLD}${GREEN}%s${RESET}\n\n" "gtk-ai installed."
-fi
-printf "To activate the Claude plugin, run:\n\n"
-printf "  ${BOLD}%s${RESET}\n\n" "claude plugin install -s user gtk-ai@gtk-ai"
-printf "Then restart Claude Code.\n\n"
+header "Done"
+success "gtk-ai $INSTALLED_VERSION configured for agent=${AGENT}"
+printf "Restart the agent after installation.\n\n"

--- a/internal/hook/agent.go
+++ b/internal/hook/agent.go
@@ -1,0 +1,36 @@
+package hook
+
+import "fmt"
+
+// Agent is a supported coding-agent integration.
+type Agent string
+
+const (
+	AgentClaudeCode Agent = "claudecode"
+	AgentCursor     Agent = "cursor"
+	AgentCodex      Agent = "codex"
+	AgentOpenCode   Agent = "opencode"
+)
+
+// ParseAgent returns a known agent or an error. s must be one of the supported names.
+func ParseAgent(s string) (Agent, error) {
+	if s == "" {
+		return "", fmt.Errorf("agent is empty")
+	}
+	switch Agent(s) {
+	case AgentClaudeCode, AgentCursor, AgentCodex, AgentOpenCode:
+		return Agent(s), nil
+	default:
+		return "", fmt.Errorf("unknown agent %q (want claudecode, cursor, codex, opencode)", s)
+	}
+}
+
+func isShellTool(name string) bool {
+	switch name {
+	case "Bash", "Shell", "bash", "shell",
+		"local_shell", "container_exec", "exec_command", "shell_command":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/hook/agent_test.go
+++ b/internal/hook/agent_test.go
@@ -1,0 +1,110 @@
+package hook_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/hook"
+)
+
+func TestParseAgent(t *testing.T) {
+	got, err := hook.ParseAgent("cursor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != hook.AgentCursor {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestParseAgentRejectsEmpty(t *testing.T) {
+	if _, err := hook.ParseAgent(""); err == nil {
+		t.Fatal("empty agent must fail")
+	}
+}
+
+func TestParseAgentRejectsUnknown(t *testing.T) {
+	if _, err := hook.ParseAgent("windsurf"); err == nil {
+		t.Fatal("unknown agent must fail")
+	}
+}
+
+func TestPostCodexIsNoop(t *testing.T) {
+	payload := mcpPayload("mcp__srv__query", strings.Repeat("x", 5000))
+	var out strings.Builder
+	ok, err := hook.Run(strings.NewReader(payload), &out, hook.AgentCodex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || out.Len() != 0 {
+		t.Fatalf("codex post must pass through, ok=%v out=%q", ok, out.String())
+	}
+}
+
+func TestPostOpenCodeRead(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("package main\n\n")
+	for i := 0; i < 100; i++ {
+		sb.WriteString("// comment line that should be stripped\n")
+		sb.WriteString("var x = 1\n")
+	}
+	payload := readPayload("main.go", sb.String())
+	var out strings.Builder
+	ok, err := hook.Run(strings.NewReader(payload), &out, hook.AgentOpenCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected opencode read filter")
+	}
+	if !strings.Contains(out.String(), `"output"`) {
+		t.Fatalf("expected opencode output field: %s", out.String())
+	}
+	if strings.Contains(out.String(), "comment line that should be stripped") {
+		t.Fatal("comments should be stripped")
+	}
+}
+
+func TestPostCursorMCP(t *testing.T) {
+	raw := strings.Repeat("This is a long MCP tool response with lots of text. ", 100)
+	contents, err := json.Marshal([]map[string]string{{"type": "text", "text": raw}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := json.Marshal(string(contents))
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"tool_name":"MCP:query_data","tool_input":{},"tool_output":` + string(output) + `}`
+	var out strings.Builder
+	ok, err := hook.Run(strings.NewReader(payload), &out, hook.AgentCursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected cursor MCP truncation")
+	}
+	if !strings.Contains(out.String(), "updated_mcp_tool_output") {
+		t.Fatalf("expected cursor MCP field: %s", out.String())
+	}
+}
+
+func TestPostCursorSkipsRead(t *testing.T) {
+	payload := readPayload("main.go", strings.Repeat("// c\nvar x = 1\n", 80))
+	var out strings.Builder
+	ok, err := hook.Run(strings.NewReader(payload), &out, hook.AgentCursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("cursor must not rewrite Read")
+	}
+}
+
+func TestPostEmptyAgent(t *testing.T) {
+	_, err := hook.Run(strings.NewReader(`{}`), &strings.Builder{}, "")
+	if err == nil {
+		t.Fatal("empty agent must fail")
+	}
+}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -55,7 +55,7 @@ func mcpPayload(toolName, text string) string {
 func runHook(t *testing.T, payload string) (modified bool, output string) {
 	t.Helper()
 	var out bytes.Buffer
-	ok, err := hook.Run(strings.NewReader(payload), &out)
+	ok, err := hook.Run(strings.NewReader(payload), &out, hook.AgentClaudeCode)
 	if err != nil {
 		t.Fatalf("hook.Run error: %v", err)
 	}

--- a/internal/hook/post_tool_use.go
+++ b/internal/hook/post_tool_use.go
@@ -1,5 +1,4 @@
-// Package hook implements the PostToolUse handler for Claude Code.
-// A single hook process handles Bash output filtering, Read filtering, and MCP passthrough.
+// Package hook implements PreToolUse and PostToolUse handlers for coding agents.
 package hook
 
 import (
@@ -27,9 +26,10 @@ type textContent struct {
 }
 
 type hookInput struct {
-	ToolName  string          `json:"tool_name"`
-	ToolInput json.RawMessage `json:"tool_input"`
-	ToolResp  json.RawMessage `json:"tool_response"`
+	ToolName   string          `json:"tool_name"`
+	ToolInput  json.RawMessage `json:"tool_input"`
+	ToolResp   json.RawMessage `json:"tool_response"`
+	ToolOutput json.RawMessage `json:"tool_output"`
 }
 
 type bashInput struct {
@@ -50,6 +50,14 @@ type hookSpecific struct {
 	HookEventName    string        `json:"hookEventName"`
 	UpdatedOutput    *string       `json:"updatedOutput,omitempty"`
 	UpdatedMCPOutput []textContent `json:"updatedMCPToolOutput,omitempty"`
+}
+
+type cursorPostOutput struct {
+	UpdatedMCPToolOutput []textContent `json:"updated_mcp_tool_output,omitempty"`
+}
+
+type openCodePostOutput struct {
+	Output string `json:"output"`
 }
 
 // ── MCP passthrough patterns ──────────────────────────────────────────────────
@@ -86,8 +94,15 @@ func matchesPassthrough(toolName string, patterns []string) bool {
 // ── Run ───────────────────────────────────────────────────────────────────────
 
 // Run reads a PostToolUse event from r, applies filtering if needed, writes result to w.
-// Returns true if output was modified.
-func Run(r io.Reader, w io.Writer) (bool, error) {
+// agent selects the stdout JSON contract of the target coding agent.
+func Run(r io.Reader, w io.Writer, agent Agent) (bool, error) {
+	if agent == "" {
+		return false, fmt.Errorf("agent is empty")
+	}
+	if agent == AgentCodex {
+		return false, nil
+	}
+
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return false, fmt.Errorf("read stdin: %w", err)
@@ -99,26 +114,28 @@ func Run(r io.Reader, w io.Writer) (bool, error) {
 	}
 
 	switch {
-	case input.ToolName == "Bash":
-		return handleBash(input, w)
-	case input.ToolName == "Read":
-		return handleRead(input, w)
-	case strings.HasPrefix(input.ToolName, "mcp__"):
-		return handleMCP(input, w)
+	case isShellTool(input.ToolName):
+		return handleBash(input, w, agent)
+	case input.ToolName == "Read" || input.ToolName == "read":
+		return handleRead(input, w, agent)
+	case strings.HasPrefix(input.ToolName, "mcp__") || strings.HasPrefix(input.ToolName, "MCP:"):
+		return handleMCP(input, w, agent)
 	}
 	return false, nil
 }
 
 // ── Bash handler ──────────────────────────────────────────────────────────────
 
-func handleBash(input hookInput, w io.Writer) (bool, error) {
-	// Extract the command that was run
+func handleBash(input hookInput, w io.Writer, agent Agent) (bool, error) {
+	if agent != AgentClaudeCode {
+		return false, nil
+	}
+
 	var bi bashInput
 	if err := json.Unmarshal(input.ToolInput, &bi); err != nil {
 		return false, nil
 	}
 
-	// Extract output
 	var resp bashResponse
 	if err := json.Unmarshal(input.ToolResp, &resp); err != nil {
 		return false, nil
@@ -127,13 +144,21 @@ func handleBash(input hookInput, w io.Writer) (bool, error) {
 		return false, nil
 	}
 
-	// Detect which module applies
 	filtered, changed := filterBashOutput(bi.Command, resp.Stdout)
 	if !changed {
 		return false, nil
 	}
 
-	return writeOutput(w, &filtered, nil)
+	return writeOutput(w, agent, &filtered, nil)
+}
+
+func responseBody(input hookInput, agent Agent) json.RawMessage {
+	switch agent {
+	case AgentCursor:
+		return input.ToolOutput
+	default:
+		return input.ToolResp
+	}
 }
 
 func filterBashOutput(command, output string) (string, bool) {
@@ -164,21 +189,14 @@ func filterBashOutput(command, output string) (string, bool) {
 
 // ── MCP handler ───────────────────────────────────────────────────────────────
 
-func handleMCP(input hookInput, w io.Writer) (bool, error) {
-	// Extract tool name from mcp__server__tool_name
-	parts := strings.SplitN(input.ToolName, "__", 3)
-	toolName := ""
-	if len(parts) == 3 {
-		toolName = parts[2]
-	}
-
-	// Passthrough: don't filter these tools
+func handleMCP(input hookInput, w io.Writer, agent Agent) (bool, error) {
+	toolName := mcpBareName(input.ToolName)
 	if matchesPassthrough(toolName, passthroughPatterns()) {
 		return false, nil
 	}
 
-	var contents []textContent
-	if err := json.Unmarshal(input.ToolResp, &contents); err != nil {
+	contents, ok := parseTextContents(responseBody(input, agent), agent)
+	if !ok {
 		return false, nil
 	}
 
@@ -195,19 +213,61 @@ func handleMCP(input hookInput, w io.Writer) (bool, error) {
 		return false, nil
 	}
 
-	return writeOutput(w, nil, contents)
+	return writeOutput(w, agent, nil, contents)
+}
+
+func readFilePath(toolInput json.RawMessage) (string, bool) {
+	var in readInput
+	if err := json.Unmarshal(toolInput, &in); err != nil || in.FilePath == "" {
+		return "", false
+	}
+	return in.FilePath, true
+}
+
+func mcpBareName(toolName string) string {
+	if strings.HasPrefix(toolName, "MCP:") {
+		return strings.TrimPrefix(toolName, "MCP:")
+	}
+	parts := strings.SplitN(toolName, "__", 3)
+	if len(parts) == 3 {
+		return parts[2]
+	}
+	return toolName
+}
+
+func parseTextContents(body json.RawMessage, agent Agent) ([]textContent, bool) {
+	if len(body) == 0 {
+		return nil, false
+	}
+	var contents []textContent
+	if err := json.Unmarshal(body, &contents); err == nil && len(contents) > 0 {
+		return contents, true
+	}
+	if agent == AgentCursor {
+		var s string
+		if err := json.Unmarshal(body, &s); err == nil && s != "" {
+			if err := json.Unmarshal([]byte(s), &contents); err == nil && len(contents) > 0 {
+				return contents, true
+			}
+		}
+	}
+	return nil, false
 }
 
 // ── Read handler ──────────────────────────────────────────────────────────────
 
-func handleRead(input hookInput, w io.Writer) (bool, error) {
-	var ri readInput
-	if err := json.Unmarshal(input.ToolInput, &ri); err != nil {
+func handleRead(input hookInput, w io.Writer, agent Agent) (bool, error) {
+	if agent == AgentCursor {
 		return false, nil
 	}
 
-	var contents []textContent
-	if err := json.Unmarshal(input.ToolResp, &contents); err != nil {
+	filePath, ok := readFilePath(input.ToolInput)
+	if !ok {
+		return false, nil
+	}
+
+	contents, ok := parseTextContents(responseBody(input, agent), agent)
+	if !ok {
 		return false, nil
 	}
 
@@ -216,7 +276,7 @@ func handleRead(input hookInput, w io.Writer) (bool, error) {
 		if c.Type != "text" || c.Text == "" {
 			continue
 		}
-		filtered, changed := readmod.FilterContent(ri.FilePath, c.Text)
+		filtered, changed := readmod.FilterContent(filePath, c.Text)
 		if changed {
 			contents[i].Text = filtered
 			modified = true
@@ -227,23 +287,47 @@ func handleRead(input hookInput, w io.Writer) (bool, error) {
 		return false, nil
 	}
 
-	return writeOutput(w, nil, contents)
+	return writeOutput(w, agent, nil, contents)
 }
 
 // ── Output writer ─────────────────────────────────────────────────────────────
 
-func writeOutput(w io.Writer, bashOut *string, mcpOut []textContent) (bool, error) {
-	spec := hookSpecific{HookEventName: "PostToolUse"}
-	if bashOut != nil {
-		spec.UpdatedOutput = bashOut
-	} else {
-		spec.UpdatedMCPOutput = mcpOut
-	}
-
-	out, err := json.Marshal(hookOutput{HookSpecificOutput: spec})
+func writeOutput(w io.Writer, agent Agent, bashOut *string, mcpOut []textContent) (bool, error) {
+	out, err := marshalPost(agent, bashOut, mcpOut)
 	if err != nil {
-		return false, fmt.Errorf("marshal: %w", err)
+		return false, err
 	}
 	_, err = fmt.Fprintln(w, string(out))
 	return true, err
+}
+
+func marshalPost(agent Agent, bashOut *string, mcpOut []textContent) ([]byte, error) {
+	switch agent {
+	case AgentClaudeCode:
+		spec := hookSpecific{HookEventName: "PostToolUse"}
+		if bashOut != nil {
+			spec.UpdatedOutput = bashOut
+		} else {
+			spec.UpdatedMCPOutput = mcpOut
+		}
+		return json.Marshal(hookOutput{HookSpecificOutput: spec})
+	case AgentCursor:
+		if len(mcpOut) == 0 {
+			return nil, fmt.Errorf("cursor post output requires MCP content")
+		}
+		return json.Marshal(cursorPostOutput{UpdatedMCPToolOutput: mcpOut})
+	case AgentOpenCode:
+		text := ""
+		if bashOut != nil {
+			text = *bashOut
+		} else if len(mcpOut) > 0 {
+			text = mcpOut[0].Text
+		}
+		if text == "" {
+			return nil, fmt.Errorf("opencode post output is empty")
+		}
+		return json.Marshal(openCodePostOutput{Output: text})
+	default:
+		return nil, fmt.Errorf("unknown agent %q", agent)
+	}
 }

--- a/internal/hook/pre_test.go
+++ b/internal/hook/pre_test.go
@@ -13,7 +13,7 @@ import (
 func TestPreRewritesGitStatus(t *testing.T) {
 	payload := `{"tool_name":"Bash","tool_input":{"command":"git status","description":"show status"}}`
 	var out bytes.Buffer
-	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestPreRewritesGitStatus(t *testing.T) {
 func TestPreLeavesEcho(t *testing.T) {
 	payload := `{"tool_name":"Bash","tool_input":{"command":"echo hi"}}`
 	var out bytes.Buffer
-	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestPreLeavesEcho(t *testing.T) {
 func TestPreLeavesGtkai(t *testing.T) {
 	payload := `{"tool_name":"Bash","tool_input":{"command":"gtkai git status"}}`
 	var out bytes.Buffer
-	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestPreLeavesGtkai(t *testing.T) {
 }
 
 func TestPreEmptyBin(t *testing.T) {
-	_, err := hook.RunPre(strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"git status"}}`), &bytes.Buffer{}, "")
+	_, err := hook.RunPre(strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"git status"}}`), &bytes.Buffer{}, "", hook.AgentClaudeCode)
 	if err == nil {
 		t.Fatal("empty gtkai path must fail")
 	}
@@ -77,7 +77,7 @@ func TestPreEmptyBin(t *testing.T) {
 func TestPreIgnoresRead(t *testing.T) {
 	payload := `{"tool_name":"Read","tool_input":{"file_path":"x.go"}}`
 	var out bytes.Buffer
-	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestPreRewritesRegisteredBash(t *testing.T) {
 	for _, cmd := range cases {
 		payload := fmt.Sprintf(`{"tool_name":"Bash","tool_input":{"command":%q}}`, cmd)
 		var out bytes.Buffer
-		ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai")
+		ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentClaudeCode)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -108,5 +108,94 @@ func TestPostSkipsGtkaiCommand(t *testing.T) {
 	modified, _ := runHook(t, bashPayload("gtkai git status", strings.Repeat("M  file.go\n", 40)))
 	if modified {
 		t.Fatal("post-hook must not filter gtkai proxy output")
+	}
+}
+
+func TestPreEmptyAgent(t *testing.T) {
+	_, err := hook.RunPre(strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"git status"}}`), &bytes.Buffer{}, "gtkai", "")
+	if err == nil {
+		t.Fatal("empty agent must fail")
+	}
+}
+
+func TestPreRewritesCursorShell(t *testing.T) {
+	payload := `{"tool_name":"Shell","tool_input":{"command":"git status","working_directory":"/proj"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentCursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	var result struct {
+		Permission   string `json:"permission"`
+		UpdatedInput struct {
+			Command          string `json:"command"`
+			WorkingDirectory string `json:"working_directory"`
+		} `json:"updated_input"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Permission != "allow" {
+		t.Fatalf("permission %q", result.Permission)
+	}
+	if result.UpdatedInput.Command != "gtkai git status" {
+		t.Fatalf("command %q", result.UpdatedInput.Command)
+	}
+	if result.UpdatedInput.WorkingDirectory != "/proj" {
+		t.Fatalf("working_directory dropped: %q", result.UpdatedInput.WorkingDirectory)
+	}
+}
+
+func TestPreRewritesCodex(t *testing.T) {
+	payload := `{"tool_name":"local_shell","tool_input":{"command":"git status"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentCodex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	var result struct {
+		HookSpecificOutput struct {
+			HookEventName      string `json:"hookEventName"`
+			PermissionDecision string `json:"permissionDecision"`
+			UpdatedInput       struct {
+				Command string `json:"command"`
+			} `json:"updatedInput"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Fatalf("permissionDecision %q", result.HookSpecificOutput.PermissionDecision)
+	}
+	if result.HookSpecificOutput.UpdatedInput.Command != "gtkai git status" {
+		t.Fatalf("command %q", result.HookSpecificOutput.UpdatedInput.Command)
+	}
+}
+
+func TestPreRewritesOpenCode(t *testing.T) {
+	payload := `{"tool_name":"bash","tool_input":{"command":"ls -la"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentOpenCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	var result struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result.Command, "gtkai ls") {
+		t.Fatalf("command %q", result.Command)
 	}
 }

--- a/internal/hook/pre_tool_use.go
+++ b/internal/hook/pre_tool_use.go
@@ -15,15 +15,29 @@ type preOutput struct {
 }
 
 type preSpecific struct {
-	HookEventName string         `json:"hookEventName"`
-	UpdatedInput  map[string]any `json:"updatedInput"`
+	HookEventName      string         `json:"hookEventName"`
+	PermissionDecision string         `json:"permissionDecision,omitempty"`
+	UpdatedInput       map[string]any `json:"updatedInput,omitempty"`
 }
 
-// RunPre reads a PreToolUse event, rewrites Bash commands to gtkai when a module matches.
+type cursorPreOutput struct {
+	Permission   string         `json:"permission"`
+	UpdatedInput map[string]any `json:"updated_input"`
+}
+
+type openCodePreOutput struct {
+	Command string `json:"command"`
+}
+
+// RunPre reads a PreToolUse event, rewrites shell commands to gtkai when a module matches.
 // gtkaiBin is the binary path inserted into the rewritten command.
-func RunPre(r io.Reader, w io.Writer, gtkaiBin string) (bool, error) {
+// agent selects the stdout JSON contract of the target coding agent.
+func RunPre(r io.Reader, w io.Writer, gtkaiBin string, agent Agent) (bool, error) {
 	if gtkaiBin == "" {
 		return false, fmt.Errorf("gtkai binary path is empty")
+	}
+	if agent == "" {
+		return false, fmt.Errorf("agent is empty")
 	}
 
 	data, err := io.ReadAll(io.LimitReader(r, stdinCap+1))
@@ -41,7 +55,7 @@ func RunPre(r io.Reader, w io.Writer, gtkaiBin string) (bool, error) {
 	if err := json.Unmarshal(data, &input); err != nil {
 		return false, nil
 	}
-	if input.ToolName != "Bash" {
+	if !isShellTool(input.ToolName) {
 		return false, nil
 	}
 
@@ -60,12 +74,38 @@ func RunPre(r io.Reader, w io.Writer, gtkaiBin string) (bool, error) {
 	}
 
 	toolInput["command"] = rewritten
-	out, err := json.Marshal(preOutput{
-		HookSpecificOutput: preSpecific{
-			HookEventName: "PreToolUse",
-			UpdatedInput:  toolInput,
-		},
-	})
+	return writePre(w, agent, toolInput, rewritten)
+}
+
+func writePre(w io.Writer, agent Agent, toolInput map[string]any, rewritten string) (bool, error) {
+	var out []byte
+	var err error
+	switch agent {
+	case AgentClaudeCode:
+		out, err = json.Marshal(preOutput{
+			HookSpecificOutput: preSpecific{
+				HookEventName: "PreToolUse",
+				UpdatedInput:  toolInput,
+			},
+		})
+	case AgentCodex:
+		out, err = json.Marshal(preOutput{
+			HookSpecificOutput: preSpecific{
+				HookEventName:      "PreToolUse",
+				PermissionDecision: "allow",
+				UpdatedInput:       toolInput,
+			},
+		})
+	case AgentCursor:
+		out, err = json.Marshal(cursorPreOutput{
+			Permission:   "allow",
+			UpdatedInput: toolInput,
+		})
+	case AgentOpenCode:
+		out, err = json.Marshal(openCodePreOutput{Command: rewritten})
+	default:
+		return false, fmt.Errorf("unknown agent %q", agent)
+	}
 	if err != nil {
 		return false, fmt.Errorf("marshal: %w", err)
 	}

--- a/internal/jsonmerge/merge.go
+++ b/internal/jsonmerge/merge.go
@@ -1,0 +1,156 @@
+// Package jsonmerge deep-merges a JSON patch into a config file.
+// Used by `gtkai json-merge` so the installer can patch hooks.json without jq.
+package jsonmerge
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// MergeFile reads filePath (or starts from {} if it does not exist),
+// reads a JSON patch from stdin, deep-merges the patch into the file,
+// and writes the result back atomically.
+//
+// Merge rules:
+//   - objects are merged recursively: patch keys are added or overwrite target
+//   - arrays are concatenated; items already present (by JSON equality) are not duplicated
+//   - scalars: patch value wins
+func MergeFile(filePath string) (changed bool, err error) {
+	if filePath == "" {
+		return false, fmt.Errorf("file path is empty")
+	}
+	var patch any
+	if err := json.NewDecoder(os.Stdin).Decode(&patch); err != nil {
+		return false, fmt.Errorf("read patch from stdin: %w", err)
+	}
+	return MergeValue(filePath, patch)
+}
+
+// MergeValue reads filePath (or starts from {} if it does not exist),
+// deep-merges patch into it, and writes the result back atomically.
+func MergeValue(filePath string, patch any) (changed bool, err error) {
+	if filePath == "" {
+		return false, fmt.Errorf("file path is empty")
+	}
+	if fi, statErr := os.Lstat(filePath); statErr == nil && fi.Mode()&os.ModeSymlink != 0 {
+		resolved, evalErr := filepath.EvalSymlinks(filePath)
+		if evalErr != nil {
+			return false, fmt.Errorf("resolve symlink %s: %w", filePath, evalErr)
+		}
+		filePath = resolved
+	} else if statErr != nil && !os.IsNotExist(statErr) {
+		return false, fmt.Errorf("stat %s: %w", filePath, statErr)
+	}
+
+	var target any = map[string]any{}
+	data, err := os.ReadFile(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return false, fmt.Errorf("read %s: %w", filePath, err)
+	}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &target); err != nil {
+			return false, fmt.Errorf("parse %s: %w", filePath, err)
+		}
+	}
+
+	merged := deepMerge(target, patch)
+
+	mergedBytes, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal result: %w", err)
+	}
+	mergedBytes = append(mergedBytes, '\n')
+
+	if len(data) > 0 {
+		var norm any
+		if json.Unmarshal(data, &norm) == nil {
+			normBytes, _ := json.MarshalIndent(norm, "", "  ")
+			normBytes = append(normBytes, '\n')
+			if string(mergedBytes) == string(normBytes) {
+				return false, nil
+			}
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		return false, fmt.Errorf("mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(filePath), ".gtkai-jsonmerge-*")
+	if err != nil {
+		return false, fmt.Errorf("tempfile: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err = tmp.Write(mergedBytes); err != nil {
+		tmp.Close()
+		return false, fmt.Errorf("write temp: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		return false, fmt.Errorf("close temp: %w", err)
+	}
+	if err = os.Rename(tmpName, filePath); err != nil {
+		return false, fmt.Errorf("rename: %w", err)
+	}
+	return true, nil
+}
+
+func deepMerge(target, patch any) any {
+	tMap, tIsMap := target.(map[string]any)
+	pMap, pIsMap := patch.(map[string]any)
+	if tIsMap && pIsMap {
+		result := make(map[string]any, len(tMap))
+		for k, v := range tMap {
+			result[k] = v
+		}
+		for k, pv := range pMap {
+			if tv, exists := result[k]; exists {
+				result[k] = deepMerge(tv, pv)
+			} else {
+				result[k] = pv
+			}
+		}
+		return result
+	}
+
+	tSlice, tIsSlice := target.([]any)
+	pSlice, pIsSlice := patch.([]any)
+	if tIsSlice && pIsSlice {
+		return dedupConcat(tSlice, pSlice)
+	}
+
+	return patch
+}
+
+func dedupConcat(a, b []any) []any {
+	result := make([]any, len(a))
+	copy(result, a)
+	for _, item := range b {
+		if !containsJSON(result, item) {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func containsJSON(slice []any, item any) bool {
+	itemBytes, err := json.Marshal(item)
+	if err != nil {
+		return false
+	}
+	for _, existing := range slice {
+		existingBytes, err := json.Marshal(existing)
+		if err != nil {
+			continue
+		}
+		if string(existingBytes) == string(itemBytes) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/jsonmerge/merge_test.go
+++ b/internal/jsonmerge/merge_test.go
@@ -1,0 +1,158 @@
+package jsonmerge
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runMerge(t *testing.T, filePath, patchJSON string) (bool, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString(patchJSON); err != nil {
+		t.Fatalf("write pipe: %v", err)
+	}
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = origStdin
+		r.Close()
+	}()
+
+	return MergeFile(filePath)
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return out
+}
+
+func TestMergeFile_EmptyPath(t *testing.T) {
+	_, err := MergeFile("")
+	if err == nil {
+		t.Fatal("empty path must fail")
+	}
+}
+
+func TestMergeFile_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+
+	patch := `{"version":1,"hooks":{"preToolUse":[{"command":"/tmp/gtkai-pre.sh","matcher":"Shell"}]}}`
+	changed, err := runMerge(t, path, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true for new file")
+	}
+
+	got := readJSON(t, path)
+	hooks, ok := got["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks not a map: %T", got["hooks"])
+	}
+	if _, exists := hooks["preToolUse"]; !exists {
+		t.Error("expected hooks.preToolUse to exist")
+	}
+}
+
+func TestMergeFile_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+
+	patch := `{"hooks":{"preToolUse":[{"command":"/tmp/gtkai-pre.sh"}]}}`
+	if _, err := runMerge(t, path, patch); err != nil {
+		t.Fatalf("first merge: %v", err)
+	}
+	changed, err := runMerge(t, path, patch)
+	if err != nil {
+		t.Fatalf("second merge: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false for idempotent merge")
+	}
+}
+
+func TestMergeFile_ArrayDedup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.json")
+
+	initial := `{"hooks":{"preToolUse":[{"command":"/existing/hook.sh"}]}}`
+	if err := os.WriteFile(path, []byte(initial), 0644); err != nil {
+		t.Fatalf("write initial: %v", err)
+	}
+
+	patch := `{"hooks":{"preToolUse":[{"command":"/tmp/gtkai-pre.sh"}]}}`
+	if _, err := runMerge(t, path, patch); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	got := readJSON(t, path)
+	hooks := got["hooks"].(map[string]any)
+	pre := hooks["preToolUse"].([]any)
+	if len(pre) != 2 {
+		t.Errorf("expected 2 preToolUse hooks, got %d", len(pre))
+	}
+
+	changed, err := runMerge(t, path, patch)
+	if err != nil {
+		t.Fatalf("second merge: %v", err)
+	}
+	if changed {
+		t.Error("expected no-op when hook already present")
+	}
+}
+
+func TestMergeFile_InvalidStdin(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	_, err := runMerge(t, path, `not valid json`)
+	if err == nil {
+		t.Error("expected error for invalid stdin JSON")
+	}
+	if !strings.Contains(err.Error(), "read patch from stdin") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Error("file should not be created on stdin error")
+	}
+}
+
+func TestMergeFile_ParentDirCreated(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "nested", "config.json")
+
+	changed, err := runMerge(t, path, `{"key":"value"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true")
+	}
+}
+
+func TestDeepMerge_ScalarPatchWins(t *testing.T) {
+	target := map[string]any{"version": float64(1)}
+	patch := map[string]any{"version": float64(2)}
+	result := deepMerge(target, patch).(map[string]any)
+	if result["version"] != float64(2) {
+		t.Errorf("expected patch value 2, got %v", result["version"])
+	}
+}

--- a/modules/mcpscan/mcpscan.go
+++ b/modules/mcpscan/mcpscan.go
@@ -247,7 +247,7 @@ func mcpHandshake(w io.Writer, r io.Reader) ([]string, error) {
 		Params: map[string]interface{}{
 			"protocolVersion": "2024-11-05",
 			"capabilities":    map[string]interface{}{},
-			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.9.0"},
+			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.10.0"},
 		},
 	}); err != nil {
 		return nil, err

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
-  "description": "PreToolUse rewrite plus PostToolUse filtering for Bash, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.9.0",
+  "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
+  "version": "0.10.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/plugin/scripts/gtkai-post-tool-use.sh
+++ b/plugin/scripts/gtkai-post-tool-use.sh
@@ -13,4 +13,4 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
-exec "$GTKAI" hook-post
+exec "$GTKAI" hook-post --agent=claudecode

--- a/scripts/claudecode/gtk-ai.md
+++ b/scripts/claudecode/gtk-ai.md
@@ -1,0 +1,8 @@
+## gtk-ai — rule-based output filtering
+
+gtk-ai filters Bash, grep, find, ls, git, and MCP tool output before it enters
+the context. Depending on the command, it applies truncation, extension grouping,
+condensed formatting, or comment line removal.
+
+The hook is active only when the Claude plugin is installed and enabled.
+Run `claude plugin install -s user gtk-ai@gtk-ai` if you have not done so.

--- a/scripts/codex/AGENTS.md
+++ b/scripts/codex/AGENTS.md
@@ -1,0 +1,3 @@
+## gtk-ai
+
+Shell commands registered with gtk-ai are rewritten to `gtkai <cmd>` before they run. Output may be compacted by truncation, grouping, or comment stripping. Do not re-run a command only because the output looks condensed: the original command still ran.

--- a/scripts/codex/hooks/gtkai-pre-tool-use.sh
+++ b/scripts/codex/hooks/gtkai-pre-tool-use.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# gtkai PreToolUse hook for Claude Code.
+# gtkai PreToolUse hook for Codex CLI (matcher Bash and shell aliases).
 
 GTKAI=$(command -v gtkai 2>/dev/null)
 if [ -z "$GTKAI" ]; then
@@ -12,4 +12,4 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
-exec "$GTKAI" hook-pre --agent=claudecode
+exec "$GTKAI" hook-pre --agent=codex

--- a/scripts/cursor/hooks/gtkai-post-tool-use.sh
+++ b/scripts/cursor/hooks/gtkai-post-tool-use.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# gtkai PreToolUse hook for Claude Code.
+# gtkai PostToolUse hook for Cursor (matcher MCP:*).
 
 GTKAI=$(command -v gtkai 2>/dev/null)
 if [ -z "$GTKAI" ]; then
@@ -12,4 +12,4 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
-exec "$GTKAI" hook-pre --agent=claudecode
+exec "$GTKAI" hook-post --agent=cursor

--- a/scripts/cursor/hooks/gtkai-pre-tool-use.sh
+++ b/scripts/cursor/hooks/gtkai-pre-tool-use.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# gtkai PreToolUse hook for Claude Code.
+# gtkai PreToolUse hook for Cursor (matcher Shell).
 
 GTKAI=$(command -v gtkai 2>/dev/null)
 if [ -z "$GTKAI" ]; then
@@ -12,4 +12,4 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
-exec "$GTKAI" hook-pre --agent=claudecode
+exec "$GTKAI" hook-pre --agent=cursor

--- a/scripts/cursor/rules/gtk-ai.mdc
+++ b/scripts/cursor/rules/gtk-ai.mdc
@@ -1,0 +1,8 @@
+---
+description: gtk-ai heuristic output filtering
+alwaysApply: true
+---
+
+## gtk-ai
+
+Shell commands registered with gtk-ai are rewritten to `gtkai <cmd>` before they run. Output may be compacted by truncation, grouping, or comment stripping. Do not re-run a command only because the output looks condensed: the original command still ran.

--- a/scripts/opencode/AGENTS.md
+++ b/scripts/opencode/AGENTS.md
@@ -1,0 +1,3 @@
+## gtk-ai
+
+Shell commands registered with gtk-ai are rewritten to `gtkai <cmd>` before they run. Output may be compacted by truncation, grouping, or comment stripping. Do not re-run a command only because the output looks condensed: the original command still ran.

--- a/scripts/opencode/plugins/gtkai.ts
+++ b/scripts/opencode/plugins/gtkai.ts
@@ -1,0 +1,90 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { existsSync } from "node:fs"
+
+function findGtkai(): string | null {
+  const fromPath = Bun.which("gtkai")
+  if (fromPath) return fromPath
+  const home = Bun.env.HOME
+  if (!home) return null
+  for (const candidate of [
+    `${home}/.local/bin/gtkai`,
+    "/usr/local/bin/gtkai",
+    "/opt/homebrew/bin/gtkai",
+  ]) {
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function runHook(gtkai: string, args: string[], payload: unknown): string {
+  const r = Bun.spawnSync([gtkai, ...args], {
+    stdin: new TextEncoder().encode(JSON.stringify(payload)),
+    stderr: "ignore",
+  })
+  if (r.exitCode !== 0 || !r.stdout) return ""
+  return r.stdout.toString().trim()
+}
+
+export const GtkAI: Plugin = async () => {
+  const gtkai = findGtkai()
+  const argsByCall = new Map<string, Record<string, unknown>>()
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      argsByCall.set(input.callID, output.args as Record<string, unknown>)
+      if (!gtkai) return
+      if (input.tool !== "bash" && input.tool !== "shell") return
+      const command = (output.args as { command?: unknown }).command
+      if (typeof command !== "string" || command === "") return
+
+      const raw = runHook(gtkai, ["hook-pre", "--agent=opencode"], {
+        tool_name: input.tool,
+        tool_input: output.args,
+      })
+      if (raw === "") return
+      let parsed: { command?: unknown }
+      try {
+        parsed = JSON.parse(raw) as { command?: unknown }
+      } catch {
+        return
+      }
+      if (typeof parsed.command !== "string" || parsed.command === "") return
+      output.args.command = parsed.command
+    },
+
+    "tool.execute.after": async (input, output) => {
+      const args = argsByCall.get(input.callID)
+      argsByCall.delete(input.callID)
+      if (!gtkai) return
+      if (args === undefined) return
+      if (input.tool === "bash" || input.tool === "shell") return
+      if (output.output === "") return
+
+      const isRead = input.tool === "read"
+      const isMCP = input.tool.startsWith("mcp__") || input.tool.startsWith("MCP:")
+      if (!isRead && !isMCP) return
+
+      let toolInput: Record<string, unknown> = args
+      if (isRead) {
+        const filePath = args.filePath
+        if (typeof filePath !== "string" || filePath === "") return
+        toolInput = { file_path: filePath }
+      }
+
+      const raw = runHook(gtkai, ["hook-post", "--agent=opencode"], {
+        tool_name: isRead ? "Read" : input.tool,
+        tool_input: toolInput,
+        tool_response: [{ type: "text", text: output.output }],
+      })
+      if (raw === "") return
+      let parsed: { output?: unknown }
+      try {
+        parsed = JSON.parse(raw) as { output?: unknown }
+      } catch {
+        return
+      }
+      if (typeof parsed.output !== "string" || parsed.output === "") return
+      output.output = parsed.output
+    },
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Integra Cursor, Codex y OpenCode con el mismo patrón que mnemo: el binario sigue siendo el proxy; `install.sh --agent=` instala los hooks de cada agente.

`gtkai hook-pre/hook-post` ahora exigen `--agent=claudecode|cursor|codex|opencode`. Codex solo reescribe shell (su PostToolUse no aplica `updatedMCPToolOutput`). Verificado con `go test ./...`, `go vet ./...` e `install.sh --agent=all` en un HOME aislado.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01243-da00-7694-8816-20755d63cdd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01243-da00-7694-8816-20755d63cdd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

