### PR TITLE
refactor: extract internal/storage for shared ~/.gtk-ai data dir

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,21 @@
+// Package storage resolves the gtk-ai data directory (~/.gtk-ai).
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Dir returns ~/.gtk-ai and ensures it exists.
+func Dir() (string, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", fmt.Errorf("HOME is not set")
+	}
+	dir := filepath.Join(home, ".gtk-ai")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,0 +1,53 @@
+package storage_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/storage"
+)
+
+func TestDir_createsDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	dir, err := storage.Dir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(tmp, ".gtk-ai")
+	if dir != want {
+		t.Fatalf("got %q, want %q", dir, want)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%q is not a directory", dir)
+	}
+}
+
+func TestDir_idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	if _, err := storage.Dir(); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := storage.Dir(); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+}
+
+func TestDir_missingHOME(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	_, err := storage.Dir()
+	if err == nil {
+		t.Fatal("expected error when HOME is empty")
+	}
+}

--- a/modules/gain/gain.go
+++ b/modules/gain/gain.go
@@ -5,10 +5,10 @@ package gain
 import (
 	"database/sql"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/jmeiracorbal/gtk-ai/internal/storage"
 	_ "modernc.org/sqlite"
 )
 
@@ -39,13 +39,9 @@ type Tracker struct {
 
 // Open opens (or creates) the gain database.
 func Open() (*Tracker, error) {
-	home := os.Getenv("HOME")
-	if home == "" {
-		return nil, fmt.Errorf("HOME is not set")
-	}
-	dir := filepath.Join(home, ".gtk-ai")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, err
+	dir, err := storage.Dir()
+	if err != nil {
+		return nil, fmt.Errorf("data dir: %w", err)
 	}
 	db, err := sql.Open("sqlite", filepath.Join(dir, "gain.db"))
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivación

`gain.Open()` construía directamente `filepath.Join(home, ".gtk-ai")` y llamaba a `os.MkdirAll`. La incorporación de `filters.db` (§4 del roadmap) repetiría esa misma lógica en un segundo paquete.

## Cambios

- Nuevo paquete `internal/storage` con `storage.Dir()`: resuelve `HOME`, garantiza que `~/.gtk-ai` existe y devuelve la ruta.
- `gain.Open()` delega en `storage.Dir()` en lugar de construir el path de forma inline.
- Tests unitarios de `storage.Dir`: creación, idempotencia y error cuando `HOME` está vacío.

## Resultado

Cualquier base de datos futura (`filters.db`, etc.) llama a `storage.Dir()` sin duplicar la lógica de resolución del directorio.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01616-f7e2-7b97-81e5-8a6c50b752ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01616-f7e2-7b97-81e5-8a6c50b752ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

