### PR TITLE
feat(manifest): campo command en gtkai.json + date@v0.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "gtk-ai",
       "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
-      "version": "0.11.0-beta.1",
+      "version": "0.11.0",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.11.0-beta.1",
+  "version": "0.11.0",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,7 +61,7 @@ The core is responsible for:
 
 One repository per intercepted shell argv0. Each filter:
 
-- Declares an `id` (`author/<cmd>`) and a `filters` field (the argv0 it intercepts).
+- Declares an `id` (`author/<cmd>`) and a `command` field (the argv0 it intercepts).
 - Implements `Rewrite` and `FilterOutput` (and optionally `ExtraEnv`).
 - Does not register agent hooks. Does not know which runtime called it.
 - Cannot bypass `never_worse`, ANSI stripping, or `gain` recording; the core applies those unconditionally.
@@ -85,9 +85,9 @@ Built-in filters (compiled into the binary) use `gtk-ai` as author. Third-party 
 
 ### Active filter resolution
 
-Many filters may declare the same `filters` value. Only one is **active** at a time:
+Many filters may declare the same `command` value. Only one is **active** at a time:
 
-- **Active** = most recently installed among all filters whose `filters` equals that command.
+- **Active** = most recently installed among all filters whose `command` equals that argv0.
 - On `filter install`, if another filter already targets the same command, abort unless `--replace` is passed. With `--replace`, the new filter becomes active; the previous one stays installed but inactive.
 - `filter install-official` (used by `install.sh`) passes `--replace` implicitly for official filters.
 - On `filter uninstall gtk-ai/ls` (full id required):
@@ -221,17 +221,17 @@ Every filter module ships a `gtkai.json` manifest at the repository root:
 ```json
 {
   "id": "author/<cmd>",
-  "filters": ["<argv0>"],
+  "command": "<argv0>",
   "platforms": ["linux/amd64", "darwin/arm64"],
   "contract": "subprocess/v1",
   "gtkai-core-version": {
-    "version": "0.10.0",
+    "version": "0.11.0",
     "constraint": "min"
   }
 }
 ```
 
-Required fields: `id`, `filters`, `platforms`, `contract`, `gtkai-core-version`.
+Required fields: `id`, `command`, `platforms`, `contract`, `gtkai-core-version`.
 
 - `id` must match `^[a-z0-9_-]+/[a-z0-9_-]+$`.
 - `contract` must be `subprocess/v1`.
@@ -240,7 +240,7 @@ Required fields: `id`, `filters`, `platforms`, `contract`, `gtkai-core-version`.
   - `"min"` — running `gtkai` must be `>= version`.
   - `"exact"` — running `gtkai` must match `version` exactly.
 
-**Module version is not in the manifest.** It is resolved from the install ref — the git tag of the filter repository. Example: `gtkai filter install github.com/gtk-ai/date@v0.11.0` installs tag `v0.11.0`; the core records that version in the registry at install time.
+**Module version is not in the manifest.** It is resolved from the install ref — the git tag of the filter repository. Example: `gtkai filter install github.com/gtk-ai/date@v0.12.0` installs tag `v0.12.0`; the core records that version in the registry at install time.
 
 On install, the core validates `gtkai-core-version` against the running binary:
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ Some commands use **external filters** — standalone repos installed separately
 ### External filter commands
 
 ```bash
-gtkai filter install github.com/gtk-ai/date@v0.11.0
-gtkai filter install github.com/gtk-ai/date@v0.11.0 --replace
-gtkai filter install-official filters/official.json --core-version=0.11.0-beta.1
+gtkai filter install github.com/gtk-ai/date@v0.12.0
+gtkai filter install github.com/gtk-ai/date@v0.12.0 --replace
+gtkai filter install-official filters/official.json --core-version=0.11.0
 gtkai filter list
 gtkai filter uninstall gtk-ai/date
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -158,7 +158,7 @@ Each filter declares, at minimum:
 | Field | Meaning |
 |---|---|
 | `id` | Full name `author/<cmd>` (must match the naming rule) |
-| `filters` | Shell command intercepted (argv0 basename), e.g. `ls` |
+| `command` | Shell command intercepted (argv0 basename), e.g. `ls` |
 
 Behavior matches today’s `Module`: `Rewrite`, `FilterOutput`, optional `ExtraEnv`. The core keeps ANSI strip, `never_worse`, and `gain`; filters do not bypass them.
 
@@ -168,7 +168,7 @@ A filter owns the full surface of that command or passes through: if it cannot h
 
 Many filters may target the same shell command. Only one is **active** at a time:
 
-- **Active filter** = the **most recently installed** among all filters whose `filters` field equals that command.
+- **Active filter** = the **most recently installed** among all filters whose `command` field equals that argv0.
 
 On **install**, when another filter already targets the same command:
 

--- a/cmd/gtkai/filter_install_test.go
+++ b/cmd/gtkai/filter_install_test.go
@@ -39,7 +39,7 @@ func TestFilterInstallOfficialAndProxyDate(t *testing.T) {
 
 	root := moduleRoot(t)
 	official := filepath.Join(root, "filters/official.json")
-	if _, err := filterinstall.InstallOfficial(official, "0.11.0-beta.1", ""); err != nil {
+	if _, err := filterinstall.InstallOfficial(official, "0.11.0", ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gtkai/filter_uninstall_test.go
+++ b/cmd/gtkai/filter_uninstall_test.go
@@ -15,7 +15,7 @@ func TestFilterUninstallCLI(t *testing.T) {
 	testhome.Isolated(t)
 	root := moduleRoot(t)
 	official := filepath.Join(root, "filters/official.json")
-	installed, err := filterinstall.InstallOfficial(official, "0.11.0-beta.1", "")
+	installed, err := filterinstall.InstallOfficial(official, "0.11.0", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,8 +40,8 @@ func TestFilterListMarksActive(t *testing.T) {
 
 	if _, err := filterinstall.Install(filterinstall.Options{
 		Module:      "github.com/gtk-ai/date",
-		Version:     "v0.11.0",
-		CoreVersion: "0.10.0",
+		Version:     "v0.12.0",
+		CoreVersion: "0.11.0",
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gtkai/integration_test.go
+++ b/cmd/gtkai/integration_test.go
@@ -166,7 +166,7 @@ func installOfficialFilters(t *testing.T) string {
 	t.Helper()
 	home := testhome.Isolated(t)
 	official := filepath.Join(moduleRoot(t), "filters/official.json")
-	if _, err := filterinstall.InstallOfficial(official, "0.11.0-beta.1", ""); err != nil {
+	if _, err := filterinstall.InstallOfficial(official, "0.11.0", ""); err != nil {
 		t.Fatal(err)
 	}
 	return home

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -30,7 +30,7 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/modules/tree"
 )
 
-const version = "0.11.0-beta.1"
+const version = "0.11.0"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s

--- a/filters/official.json
+++ b/filters/official.json
@@ -2,7 +2,7 @@
   "filters": [
     {
       "module": "github.com/gtk-ai/date",
-      "version": "v0.11.0"
+      "version": "v0.12.0"
     }
   ]
 }

--- a/internal/filterinstall/install.go
+++ b/internal/filterinstall/install.go
@@ -75,7 +75,7 @@ func Install(opts Options) (*filterregistry.Record, error) {
 		return nil, err
 	}
 	defer db.Close()
-	if err := checkReplaceConflict(db, manifest.ID, manifest.Filters[0], opts.Replace); err != nil {
+	if err := checkReplaceConflict(db, manifest.ID, manifest.Command, opts.Replace); err != nil {
 		return nil, err
 	}
 
@@ -101,7 +101,7 @@ func Install(opts Options) (*filterregistry.Record, error) {
 		ID:           manifest.ID,
 		Module:       opts.Module,
 		Version:      opts.Version,
-		Argv0:        manifest.Filters[0],
+		Argv0:        manifest.Command,
 		Contract:     manifest.Contract,
 		BinaryPath:   destBin,
 		ManifestPath: destManifest,

--- a/internal/filterinstall/install_test.go
+++ b/internal/filterinstall/install_test.go
@@ -33,8 +33,8 @@ func TestInstallGtkaiDateRemote(t *testing.T) {
 
 	rec, err := filterinstall.Install(filterinstall.Options{
 		Module:      "github.com/gtk-ai/date",
-		Version:     "v0.11.0",
-		CoreVersion: "0.10.0",
+		Version:     "v0.12.0",
+		CoreVersion: "0.11.0",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -71,7 +71,7 @@ func TestInstallOfficial(t *testing.T) {
 
 	root := moduleRoot(t)
 	official := filepath.Join(root, "filters/official.json")
-	installed, err := filterinstall.InstallOfficial(official, "0.11.0-beta.1", "")
+	installed, err := filterinstall.InstallOfficial(official, "0.11.0", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/filterinstall/uninstall_test.go
+++ b/internal/filterinstall/uninstall_test.go
@@ -57,8 +57,8 @@ func TestInstallConflictAbortsWithoutReplace(t *testing.T) {
 
 	_, err = filterinstall.Install(filterinstall.Options{
 		Module:      "github.com/gtk-ai/date",
-		Version:     "v0.11.0",
-		CoreVersion: "0.10.0",
+		Version:     "v0.12.0",
+		CoreVersion: "0.11.0",
 	})
 	if err == nil {
 		t.Fatal("expected install to abort without --replace")
@@ -106,8 +106,8 @@ func TestInstallConflictWithReplace(t *testing.T) {
 	stderr := captureStderr(t, func() {
 		if _, err := filterinstall.Install(filterinstall.Options{
 			Module:      "github.com/gtk-ai/date",
-			Version:     "v0.11.0",
-			CoreVersion: "0.10.0",
+			Version:     "v0.12.0",
+			CoreVersion: "0.11.0",
 			Replace:     true,
 		}); err != nil {
 			t.Fatal(err)
@@ -143,8 +143,8 @@ func TestUninstallRemovesInstallDir(t *testing.T) {
 
 	rec, err := filterinstall.Install(filterinstall.Options{
 		Module:      "github.com/gtk-ai/date",
-		Version:     "v0.11.0",
-		CoreVersion: "0.10.0",
+		Version:     "v0.12.0",
+		CoreVersion: "0.11.0",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -203,8 +203,8 @@ func TestUninstallPromotesPreviousFilter(t *testing.T) {
 
 	newer, err := filterinstall.Install(filterinstall.Options{
 		Module:      "github.com/gtk-ai/date",
-		Version:     "v0.11.0",
-		CoreVersion: "0.10.0",
+		Version:     "v0.12.0",
+		CoreVersion: "0.11.0",
 		Replace:     true,
 	})
 	if err != nil {

--- a/internal/filtermanifest/manifest.go
+++ b/internal/filtermanifest/manifest.go
@@ -18,8 +18,8 @@ func (m *Manifest) Validate(runningGtkai, platform string) error {
 	if !idRegex.MatchString(m.ID) {
 		return fmt.Errorf("id %q does not match naming rule", m.ID)
 	}
-	if len(m.Filters) == 0 {
-		return fmt.Errorf("filters must not be empty")
+	if strings.TrimSpace(m.Command) == "" {
+		return fmt.Errorf("command must not be empty")
 	}
 	if m.Contract != "subprocess/v1" {
 		return fmt.Errorf("contract must be subprocess/v1, got %q", m.Contract)
@@ -51,7 +51,7 @@ const ManifestFileName = "gtkai.json"
 // Manifest is the required gtkai.json schema for subprocess/v1 filters.
 type Manifest struct {
 	ID               string           `json:"id"`
-	Filters          []string         `json:"filters"`
+	Command          string           `json:"command"`
 	Platforms        []string         `json:"platforms"`
 	Contract         string           `json:"contract"`
 	GtkaiCoreVersion GtkaiCoreVersion `json:"gtkai-core-version"`

--- a/internal/filtermanifest/manifest_test.go
+++ b/internal/filtermanifest/manifest_test.go
@@ -85,8 +85,28 @@ func TestValidateGtkaiCoreVersionUnknownConstraint(t *testing.T) {
 	}
 }
 
+func TestValidateCommandEmpty(t *testing.T) {
+	m := &filtermanifest.Manifest{
+		ID:       "gtk-ai/date",
+		Command:  "",
+		Contract: "subprocess/v1",
+		GtkaiCoreVersion: filtermanifest.GtkaiCoreVersion{
+			Version:    "0.11.0",
+			Constraint: "min",
+		},
+		Platforms: []string{"linux/amd64"},
+	}
+	err := m.Validate("0.11.0", "linux/amd64")
+	if err == nil {
+		t.Fatal("expected error for empty command")
+	}
+	if !strings.Contains(err.Error(), "command must not be empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseGtkaiDateManifest(t *testing.T) {
-	dir, err := downloadModuleDir("github.com/gtk-ai/date@v0.11.0")
+	dir, err := downloadModuleDir("github.com/gtk-ai/date@v0.12.0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,10 +117,13 @@ func TestParseGtkaiDateManifest(t *testing.T) {
 	if m.ID != "gtk-ai/date" {
 		t.Fatalf("id %q", m.ID)
 	}
+	if m.Command != "date" {
+		t.Fatalf("command %q", m.Command)
+	}
 	if m.GtkaiCoreVersion.Constraint != "min" {
 		t.Fatalf("constraint %q", m.GtkaiCoreVersion.Constraint)
 	}
-	if err := m.ValidateGtkaiCoreVersion("0.10.0"); err != nil {
+	if err := m.ValidateGtkaiCoreVersion("0.11.0"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/modules/mcpscan/mcpscan.go
+++ b/modules/mcpscan/mcpscan.go
@@ -247,7 +247,7 @@ func mcpHandshake(w io.Writer, r io.Reader) ([]string, error) {
 		Params: map[string]interface{}{
 			"protocolVersion": "2024-11-05",
 			"capabilities":    map[string]interface{}{},
-			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.11.0-beta.1"},
+			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.11.0"},
 		},
 	}); err != nil {
 		return nil, err

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.11.0-beta.1",
+  "version": "0.11.0",
   "author": {
     "name": "jmeiracorbal"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

Breaking change en el esquema de `gtkai.json` para filtros externos: `filters: ["ls"]` pasa a `command: "ls"` (string, un módulo = un comando).

Alineado con [github.com/gtk-ai/date@v0.12.0](https://github.com/gtk-ai/date/releases/tag/v0.12.0).

## Cambios

- `internal/filtermanifest`: `Command string` con validación `command must not be empty`
- `internal/filterinstall`: registro y resolución de conflicto usan `manifest.Command`
- `filters/official.json`: `v0.12.0`
- Core **0.11.0** (requerido por `date@v0.12.0`; la beta `0.11.0-beta.1` es semver inferior a `0.11.0`)
- Tests y docs (`ARCHITECTURE.md`, `README.md`, `ROADMAP.md`) actualizados

## Ejemplo de manifiesto

```json
{
  "id": "gtk-ai/date",
  "command": "date",
  "platforms": ["linux/amd64", "darwin/arm64"],
  "contract": "subprocess/v1",
  "gtkai-core-version": { "version": "0.11.0", "constraint": "min" }
}
```

## Verificación

```bash
go test ./...
gtkai filter install github.com/gtk-ai/date@v0.12.0
```

**Nota:** `filters/official.json` conserva la clave `"filters"` como lista de módulos oficiales a instalar; es independiente del campo `command` del manifiesto.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01a6d-2934-7e85-9f92-e764e2860ad2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01a6d-2934-7e85-9f92-e764e2860ad2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

