### PR TITLE
fix(ci): extraer versiones pre-release en check de consistencia

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Check version consistency
         run: |
-          go_ver=$(grep 'const version = ' cmd/gtkai/main.go | sed 's/.*"\([0-9.]*\)".*/\1/')
+          go_ver=$(grep 'const version = ' cmd/gtkai/main.go | sed 's/.*"\([^"]*\)".*/\1/')
           if [ -z "$go_ver" ]; then
             echo "could not extract version from cmd/gtkai/main.go"
             exit 1
@@ -47,7 +47,7 @@ jobs:
           check ".claude-plugin/marketplace.json"   "$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)"
           check ".claude-plugin/plugin.json"        "$(jq -r '.version' .claude-plugin/plugin.json)"
           check "plugin/.claude-plugin/plugin.json" "$(jq -r '.version' plugin/.claude-plugin/plugin.json)"
-          check "modules/mcpscan/mcpscan.go"        "$(sed -n 's/.*"version": "\([0-9.]*\)".*/\1/p' modules/mcpscan/mcpscan.go | head -1)"
+          check "modules/mcpscan/mcpscan.go"        "$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' modules/mcpscan/mcpscan.go | head -1)"
           exit $failed
 
       - name: Check plugin manifest field consistency


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

El step `Check version consistency` en CI usaba:

```bash
sed 's/.*"\([0-9.]*\)".*/\1/'
```

Con `0.11.0-beta.2`, el grupo `[0-9.]*` puede coincidir con cadena vacía antes de la comilla de apertura, dejando `go_ver` vacío y fallando el action con:

```
canonical version:
```

## Fix

Alinear con `release.yml`: usar `[^"]*` para capturar la versión completa, incluyendo pre-releases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01a6d-2934-7e85-9f92-e764e2860ad2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01a6d-2934-7e85-9f92-e764e2860ad2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

