### PR TITLE
chore(release): bump to 0.11.0-beta.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "gtk-ai",
       "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
-      "version": "0.11.0-beta.2",
+      "version": "0.11.0-beta.3",
       "author": {
         "name": "jmeiracorbal"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.11.0-beta.2",
+  "version": "0.11.0-beta.3",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ When changing the version, update every file that exposes it:
 - `cmd/gtkai/main.go`
 - `.claude-plugin/plugin.json`
 - `.claude-plugin/marketplace.json`
-- `plugin/.claude-plugin/plugin.json`
+- `integrations/claude/.claude-plugin/plugin.json`
 - `plugins/mcpscan/mcpscan.go`
 - `README.md`
 
@@ -49,6 +49,17 @@ External plugins are binaries that implement the `registry.Module` interface via
 | `pluginmanifest` | Parses and validates `gtkai.json` plugin manifests |
 
 Built-in plugins in `plugins/` are compiled into the binary and registered via `init()`. External plugins from the marketplace are subprocess-based (JSON protocol). Both implement `registry.Module` — the proxy treats them identically.
+
+## Post-merge <!-- post-merge-workflow -->
+
+After merging a PR:
+
+1. Switch to `main` locally and pull.
+2. Run `go test ./...` — or the test most relevant to the change.
+   - If a gap appears: open a new branch, fix it, push and open a PR.
+3. If all green: bump the version in every file listed under **Versions**.
+4. Update documentation if the change affects user-facing behavior.
+5. Push a new git tag matching the version (`git tag vX.Y.Z && git push origin vX.Y.Z`).
 
 ## Before committing
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Command filters ship as standalone repos (for example `github.com/gtk-ai/date`).
 ```bash
 gtkai filter install github.com/gtk-ai/date@v0.12.0
 gtkai filter install github.com/gtk-ai/date@v0.12.0 --replace
-gtkai filter install-marketplace marketplace.json --core-version=0.11.0-beta.2
+gtkai filter install-marketplace marketplace.json --core-version=0.11.0-beta.3
 gtkai filter list
 gtkai filter uninstall gtk-ai/date
 ```

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -30,7 +30,7 @@ import (
 	_ "github.com/jmeiracorbal/gtk-ai/plugins/tree"
 )
 
-const version = "0.11.0-beta.2"
+const version = "0.11.0-beta.3"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s

--- a/integrations/claude/.claude-plugin/plugin.json
+++ b/integrations/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtk-ai",
   "description": "PreToolUse rewrite plus PostToolUse filtering for shell, git, grep, find, ls, Read, and MCP tool output.",
-  "version": "0.11.0-beta.2",
+  "version": "0.11.0-beta.3",
   "author": {
     "name": "jmeiracorbal"
   },

--- a/plugins/mcpscan/mcpscan.go
+++ b/plugins/mcpscan/mcpscan.go
@@ -247,7 +247,7 @@ func mcpHandshake(w io.Writer, r io.Reader) ([]string, error) {
 		Params: map[string]interface{}{
 			"protocolVersion": "2024-11-05",
 			"capabilities":    map[string]interface{}{},
-			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.11.0-beta.2"},
+			"clientInfo":      map[string]interface{}{"name": "gtkai", "version": "0.11.0-beta.3"},
 		},
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
Actualiza la versión a `0.11.0-beta.3` tras los refactors de las PRs #24 y #25.

## Archivos actualizados

- `cmd/gtkai/main.go`
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `integrations/claude/.claude-plugin/plugin.json`
- `plugins/mcpscan/mcpscan.go`
- `README.md`
- `AGENTS.md` (ruta de versión actualizada a `integrations/claude/` y flujo post-merge documentado)