### PR TITLE
feat(skill): add global gtk-ai skill with .gtkai guardrail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 
 .claude/
 .hybrid-coco/
+.gtkai

--- a/cmd/gtkai/assets_test.go
+++ b/cmd/gtkai/assets_test.go
@@ -20,7 +20,7 @@ func TestShippedAgentAssets(t *testing.T) {
 		"integrations/codex/AGENTS.md",
 		"integrations/opencode/plugins/gtkai.ts",
 		"integrations/opencode/AGENTS.md",
-		"scripts/claudecode/gtk-ai.md",
+		"skills/gtk-ai/SKILL.md",
 	}
 	for _, rel := range files {
 		path := filepath.Join(root, rel)

--- a/cmd/gtkai/install_test.go
+++ b/cmd/gtkai/install_test.go
@@ -91,26 +91,27 @@ func TestInstallClaudeCode(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("claudecode install exit %d:\n%s", code, out)
 	}
-	// settings.json debe existir con la clave extraKnownMarketplaces
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
-	if _, err := os.Stat(settingsPath); err != nil {
-		t.Fatalf("settings.json not created: %v", err)
+	// skill must be installed in the global store
+	skillPath := filepath.Join(home, ".agents", "skills", "gtk-ai", "SKILL.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("SKILL.md not in global store: %v", err)
 	}
-	data, _ := os.ReadFile(settingsPath)
-	if !strings.Contains(string(data), "gtk-ai") {
-		t.Fatalf("settings.json does not contain gtk-ai entry:\n%s", data)
-	}
-	// gtk-ai.md debe existir
-	if _, err := os.Stat(filepath.Join(home, ".claude", "gtk-ai.md")); err != nil {
-		t.Fatalf("gtk-ai.md not created: %v", err)
-	}
-	// CLAUDE.md debe incluir @gtk-ai.md
-	claudeMD, err := os.ReadFile(filepath.Join(home, ".claude", "CLAUDE.md"))
+	// ~/.claude/skills/gtk-ai must be a symlink pointing to the global store
+	linkPath := filepath.Join(home, ".claude", "skills", "gtk-ai")
+	info, err := os.Lstat(linkPath)
 	if err != nil {
-		t.Fatalf("CLAUDE.md not created: %v", err)
+		t.Fatalf("claude skill symlink not created: %v", err)
 	}
-	if !strings.Contains(string(claudeMD), "@gtk-ai.md") {
-		t.Fatalf("CLAUDE.md does not include @gtk-ai.md:\n%s", claudeMD)
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("~/.claude/skills/gtk-ai is not a symlink")
+	}
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	expected := filepath.Join(home, ".agents", "skills", "gtk-ai")
+	if target != expected {
+		t.Fatalf("symlink target: got %q, want %q", target, expected)
 	}
 }
 
@@ -146,6 +147,22 @@ func TestInstallCursor(t *testing.T) {
 	// regla de contexto
 	if _, err := os.Stat(filepath.Join(home, ".cursor", "rules", "gtk-ai.mdc")); err != nil {
 		t.Fatalf("gtk-ai.mdc rule not installed: %v", err)
+	}
+	// skill symlink
+	linkPath := filepath.Join(home, ".cursor", "skills", "gtk-ai")
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("cursor skill symlink not created: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("~/.cursor/skills/gtk-ai is not a symlink")
+	}
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("readlink cursor skill: %v", err)
+	}
+	if target != filepath.Join(home, ".agents", "skills", "gtk-ai") {
+		t.Fatalf("cursor skill symlink target: got %q", target)
 	}
 }
 
@@ -183,6 +200,22 @@ func TestInstallCodex(t *testing.T) {
 	if !strings.Contains(string(configTOML), "codex_hooks") {
 		t.Fatalf("config.toml does not enable codex_hooks:\n%s", configTOML)
 	}
+	// skill symlink
+	linkPath := filepath.Join(home, ".codex", "skills", "gtk-ai")
+	info, err = os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("codex skill symlink not created: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("~/.codex/skills/gtk-ai is not a symlink")
+	}
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("readlink codex skill: %v", err)
+	}
+	if target != filepath.Join(home, ".agents", "skills", "gtk-ai") {
+		t.Fatalf("codex skill symlink target: got %q", target)
+	}
 }
 
 func TestInstallOpenCode(t *testing.T) {
@@ -213,7 +246,7 @@ func TestInstallUnknownAgentFails(t *testing.T) {
 }
 
 // TestInstallIdempotentClaudeCode verifica que ejecutar install.sh dos veces
-// no duplica entradas en CLAUDE.md ni falla.
+// no falla y el symlink queda apuntando al target correcto.
 func TestInstallIdempotentClaudeCode(t *testing.T) {
 	home := t.TempDir()
 	installDir := t.TempDir()
@@ -225,12 +258,13 @@ func TestInstallIdempotentClaudeCode(t *testing.T) {
 			t.Fatalf("run %d exit %d:\n%s", i+1, code, out)
 		}
 	}
-	claudeMD, err := os.ReadFile(filepath.Join(home, ".claude", "CLAUDE.md"))
+	linkPath := filepath.Join(home, ".claude", "skills", "gtk-ai")
+	target, err := os.Readlink(linkPath)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("readlink after 2 runs: %v", err)
 	}
-	count := strings.Count(string(claudeMD), "@gtk-ai.md")
-	if count != 1 {
-		t.Fatalf("expected exactly 1 @gtk-ai.md entry, got %d:\n%s", count, claudeMD)
+	expected := filepath.Join(home, ".agents", "skills", "gtk-ai")
+	if target != expected {
+		t.Fatalf("symlink target after 2 runs: got %q, want %q", target, expected)
 	}
 }

--- a/install.sh
+++ b/install.sh
@@ -303,30 +303,30 @@ resolve_scripts() {
   TMP_ROOT="$TMP_DIR/gtk-ai-scripts"
 }
 
+install_skill_global() {
+  AGENTS_SKILL_DIR="$HOME/.agents/skills/gtk-ai"
+  mkdir -p "$AGENTS_SKILL_DIR"
+  cp "$TMP_ROOT/skills/gtk-ai/SKILL.md" "$AGENTS_SKILL_DIR/SKILL.md"
+  success "$HOME/.agents/skills/gtk-ai/SKILL.md written"
+}
+
+install_skill_symlink() {
+  link_dir="$1"
+  target="$HOME/.agents/skills/gtk-ai"
+  link="$link_dir/gtk-ai"
+  mkdir -p "$link_dir"
+  if [ -L "$link" ] || [ -e "$link" ]; then
+    rm -f "$link"
+  fi
+  ln -s "$target" "$link"
+  success "${link} -> ${target}"
+}
+
 setup_claudecode() {
   header "Configuring Claude Code"
 
-  CLAUDE_DIR="$HOME/.claude"
-  SETTINGS_FILE="$CLAUDE_DIR/settings.json"
-  PROTOCOL_DOC="$CLAUDE_DIR/gtk-ai.md"
-  CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
-
-  mkdir -p "$CLAUDE_DIR"
-
-  cp "$TMP_ROOT/scripts/claudecode/gtk-ai.md" "$PROTOCOL_DOC"
-  success "$HOME/.claude/gtk-ai.md written"
-
-  if [ -f "$CLAUDE_MD" ]; then
-    if grep -q "@gtk-ai.md" "$CLAUDE_MD" 2>/dev/null; then
-      info "$HOME/.claude/CLAUDE.md — already up to date"
-    else
-      printf '\n@gtk-ai.md\n' >> "$CLAUDE_MD"
-      success "$HOME/.claude/CLAUDE.md updated"
-    fi
-  else
-    printf '@gtk-ai.md\n' > "$CLAUDE_MD"
-    success "$HOME/.claude/CLAUDE.md created"
-  fi
+  install_skill_global
+  install_skill_symlink "$HOME/.claude/skills"
 
   printf "To activate the Claude plugin, run:\n\n"
   printf "  ${BOLD}%s${RESET}\n\n" "claude plugin install -s user gtk-ai@gtk-ai"
@@ -352,6 +352,9 @@ setup_cursor() {
 
   cp "$TMP_ROOT/integrations/cursor/rules/gtk-ai.mdc" "$rules_dir/gtk-ai.mdc"
   success "$HOME/.cursor/rules/gtk-ai.mdc written"
+
+  install_skill_global
+  install_skill_symlink "$HOME/.cursor/skills"
 }
 
 setup_codex() {
@@ -387,6 +390,9 @@ setup_codex() {
   fi
 
   append_marked_block "$agents_md" "$TMP_ROOT/integrations/codex/AGENTS.md"
+
+  install_skill_global
+  install_skill_symlink "$HOME/.codex/skills"
 }
 
 setup_opencode() {

--- a/integrations/opencode/AGENTS.md
+++ b/integrations/opencode/AGENTS.md
@@ -1,3 +1,15 @@
 ## gtk-ai
 
 Shell commands registered with gtk-ai are rewritten to `gtkai <cmd>` before they run. Output may be compacted by truncation, grouping, or comment stripping. Do not re-run a command only because the output looks condensed: the original command still ran.
+
+Load and follow the `gtk-ai` skill when it is available for the detailed protocol. These rules remain active when the skill is not loaded.
+
+### Active when
+
+gtk-ai is enabled for a project when `.gtkai` exists at the repository root. If it is missing, filtering may still occur but the project has not opted in.
+
+### Behavior
+
+- Compact or truncated output is intentional — do not re-run commands to bypass it.
+- The proxy passes through any command it has no rule for, unchanged.
+- If `gtkai` is not in PATH, the hook exits silently and commands run unmodified.

--- a/scripts/claudecode/gtk-ai.md
+++ b/scripts/claudecode/gtk-ai.md
@@ -1,8 +1,0 @@
-## gtk-ai — rule-based output filtering
-
-gtk-ai filters Bash, grep, find, ls, git, and MCP tool output before it enters
-the context. Depending on the command, it applies truncation, extension grouping,
-condensed formatting, or comment line removal.
-
-The hook is active only when the Claude plugin is installed and enabled.
-Run `claude plugin install -s user gtk-ai@gtk-ai` if you have not done so.

--- a/skills/gtk-ai/SKILL.md
+++ b/skills/gtk-ai/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: gtk-ai
+description: Active when gtkai binary is in PATH — transparent command proxy and output filter for git, grep, rg, find, ls, docker, cargo, go, python, pytest, npm, tree, and MCP Read output. Load to understand filtering behavior and avoid misinterpreting compact output.
+---
+
+# gtk-ai
+
+gtk-ai intercepts shell commands before they run (PreToolUse rewrite) and compacts their output after (PostToolUse filter). The proxy is transparent: it exits silently when the binary is absent, and passes through any command it has no rule for.
+
+## 1. Verify the proxy is active
+
+Before assuming gtk-ai is intercepting commands:
+
+```bash
+command -v gtkai
+```
+
+If the binary is not found, the proxy is inactive. Commands run unmodified and output is unfiltered. No further steps in this skill apply.
+
+## 2. Commands intercepted
+
+These commands are automatically rewritten to `gtkai <cmd> <args>` before running:
+
+| Command | Effect |
+|---|---|
+| `git` | `--no-pager`, stats on diff, log truncation |
+| `grep` / `rg` | matches grouped by file, line limits |
+| `find` | truncates deep listings, strips empty results |
+| `ls` | groups by extension, line limit |
+| `docker` | strips build and log noise |
+| `cargo` / `go` | compact build and test output |
+| `python` / `pytest` | compact failure output |
+| `npm test` / `npx` | compact vitest/jest output |
+| `tree` | depth and line limits |
+| `read` (MCP Read tool) | file size truncation |
+
+MCP tool output is also filtered after execution when a rule matches.
+
+## 3. Interpreting filtered output
+
+Compact or truncated output is intentional. Do not:
+
+- Re-run the command with broader flags to retrieve the full output
+- Interpret a shorter-than-expected result as a failure
+- Add flags like `--no-filter` that do not exist in the real tool
+
+If the full output is genuinely needed for the task, bypass filtering for that call:
+
+```bash
+gtkai proxy <cmd> <args>
+```
+
+## 4. Token analytics
+
+```bash
+gtkai gain
+```
+
+Shows cumulative token savings across sessions, broken down by command.

--- a/skills/gtk-ai/SKILL.md
+++ b/skills/gtk-ai/SKILL.md
@@ -1,21 +1,28 @@
 ---
 name: gtk-ai
-description: Active when gtkai binary is in PATH — transparent command proxy and output filter for git, grep, rg, find, ls, docker, cargo, go, python, pytest, npm, tree, and MCP Read output. Load to understand filtering behavior and avoid misinterpreting compact output.
+description: Active when .gtkai exists at the repo root — transparent command proxy and output filter for git, grep, rg, find, ls, docker, cargo, go, python, pytest, npm, tree, and MCP Read output. Load to understand filtering behavior and avoid misinterpreting compact output.
 ---
 
 # gtk-ai
 
 gtk-ai intercepts shell commands before they run (PreToolUse rewrite) and compacts their output after (PostToolUse filter). The proxy is transparent: it exits silently when the binary is absent, and passes through any command it has no rule for.
 
-## 1. Verify the proxy is active
+## 1. Verify the proxy is active for this project
 
-Before assuming gtk-ai is intercepting commands:
+Before applying gtk-ai context:
+
+1. Resolve the Git repository root, or use the current workspace if it is not a Git repository.
+2. Read `<root>/.gtkai`.
+3. Continue only when the file is present.
+4. Confirm the binary is available: `command -v gtkai`.
+
+If `.gtkai` is missing, gtk-ai is not initialized for this project. Create it to enable filtering:
 
 ```bash
-command -v gtkai
+echo '{}' > .gtkai
 ```
 
-If the binary is not found, the proxy is inactive. Commands run unmodified and output is unfiltered. No further steps in this skill apply.
+If `gtkai` is not in PATH, the binary is not installed. No filtering will occur regardless of the marker.
 
 ## 2. Commands intercepted
 


### PR DESCRIPTION
## Cambios

- Añade `skills/gtk-ai/SKILL.md`: skill que el agente carga cuando `.gtkai` existe en el repo root. Describe los comandos interceptados, cómo interpretar el output compacto, y cómo bypasear el filtro.
- Elimina `scripts/claudecode/gtk-ai.md` y el directorio `scripts/`: redundante con el skill.
- `install.sh`: reescrito `setup_claudecode()` con helpers `install_skill_global()` e `install_skill_symlink()`. Los mismos helpers se aplican a Cursor y Codex. Instala el skill en `~/.agents/skills/gtk-ai/` y crea un symlink desde cada agente.
- `integrations/opencode/AGENTS.md`: referencia al skill por nombre y condición de activación `.gtkai` (OpenCode no tiene directorio `skills/`).
- `.gitignore`: añade `.gtkai` — el marker es local y no se versiona.
- Tests: `assets_test.go` apunta a `skills/gtk-ai/SKILL.md`; `install_test.go` verifica symlinks para Claude Code, Cursor y Codex.

## Guardrail

El skill se activa solo cuando `.gtkai` existe en el root del repo. Mismo patrón que `.mnemo` en el proyecto mnemo.

```bash
echo '{}' > .gtkai
```

## Instalación del skill

```
~/.agents/skills/gtk-ai/SKILL.md   <- store global
~/.claude/skills/gtk-ai            -> ~/.agents/skills/gtk-ai
~/.cursor/skills/gtk-ai            -> ~/.agents/skills/gtk-ai
~/.codex/skills/gtk-ai             -> ~/.agents/skills/gtk-ai
```

## Test plan

- [x] `go test ./...` pasa (213 tests)
- [x] `install.sh --agent=claudecode` crea el symlink `~/.claude/skills/gtk-ai`
- [x] `install.sh --agent=cursor` crea el symlink `~/.cursor/skills/gtk-ai`
- [x] `install.sh --agent=codex` crea el symlink `~/.codex/skills/gtk-ai`
- [x] Sin `.gtkai` en el repo, el skill no aplica guardrail