### PR TITLE
fix(codex): remove legacy codex_hooks flag, add Codex pre-tool-use tests

### DIFF
--- a/cmd/gtkai/install_test.go
+++ b/cmd/gtkai/install_test.go
@@ -192,13 +192,10 @@ func TestInstallCodex(t *testing.T) {
 	if !strings.Contains(string(hooksJSON), "PreToolUse") {
 		t.Fatalf("hooks.json does not register PreToolUse:\n%s", hooksJSON)
 	}
-	// config.toml debe habilitar codex_hooks
-	configTOML, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
-	if err != nil {
-		t.Fatalf("config.toml not created: %v", err)
-	}
-	if !strings.Contains(string(configTOML), "codex_hooks") {
-		t.Fatalf("config.toml does not enable codex_hooks:\n%s", configTOML)
+	// config.toml must NOT contain the legacy codex_hooks entry (Codex 0.149.1+)
+	configTOML, _ := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if strings.Contains(string(configTOML), "codex_hooks") {
+		t.Fatalf("config.toml must not contain legacy codex_hooks:\n%s", configTOML)
 	}
 	// skill symlink
 	linkPath := filepath.Join(home, ".codex", "skills", "gtk-ai")

--- a/install.sh
+++ b/install.sh
@@ -376,17 +376,23 @@ setup_codex() {
 
   mkdir -p "$HOME/.codex"
   touch "$codex_config"
+  # Codex 0.149.1+: hooks activate via hooks.json alone; [features] codex_hooks is legacy.
+  # Remove the entry if a previous install wrote it, and drop the [features] header
+  # if it becomes empty.
   if grep -q 'codex_hooks' "$codex_config" 2>/dev/null; then
-    info "$HOME/.codex/config.toml — codex_hooks already set"
-  elif grep -q '^\[features\]' "$codex_config" 2>/dev/null; then
     tmp_cfg=$(mktemp)
-    awk '/^\[features\]/{print; print "codex_hooks = true"; next} {print}' "$codex_config" > "$tmp_cfg"
+    grep -v '^codex_hooks[[:space:]]*=' "$codex_config" | \
+      awk '
+        /^\[features\]/ { saved=$0; next }
+        saved != "" {
+          if (/^[[:space:]]*$/) { next }
+          if (/^\[/) { saved=""; print; next }
+          print saved; saved=""
+        }
+        { print }
+      ' > "$tmp_cfg"
     mv "$tmp_cfg" "$codex_config"
-    success "$HOME/.codex/config.toml — enabled [features].codex_hooks"
-  else
-    tail -c1 "$codex_config" 2>/dev/null | grep -q $'\n' || printf '\n' >> "$codex_config"
-    printf '\n[features]\ncodex_hooks = true\n' >> "$codex_config"
-    success "$HOME/.codex/config.toml — enabled [features].codex_hooks"
+    success "$HOME/.codex/config.toml — removed legacy codex_hooks (Codex 0.149.1+)"
   fi
 
   append_marked_block "$agents_md" "$TMP_ROOT/integrations/codex/AGENTS.md"

--- a/internal/hook/pre_test.go
+++ b/internal/hook/pre_test.go
@@ -179,6 +179,82 @@ func TestPreRewritesCodex(t *testing.T) {
 	}
 }
 
+func TestPreRewritesCodexHookEventName(t *testing.T) {
+	payload := `{"tool_name":"local_shell","tool_input":{"command":"git status"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentCodex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected rewrite")
+	}
+	var result struct {
+		HookSpecificOutput struct {
+			HookEventName string `json:"hookEventName"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.HookSpecificOutput.HookEventName != "PreToolUse" {
+		t.Fatalf("hookEventName %q", result.HookSpecificOutput.HookEventName)
+	}
+}
+
+func TestPreRewritesCodexBash(t *testing.T) {
+	payload := `{"tool_name":"Bash","tool_input":{"command":"git status"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentCodex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected rewrite for Bash tool")
+	}
+	var result struct {
+		HookSpecificOutput struct {
+			PermissionDecision string `json:"permissionDecision"`
+			UpdatedInput       struct {
+				Command string `json:"command"`
+			} `json:"updatedInput"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Fatalf("permissionDecision %q", result.HookSpecificOutput.PermissionDecision)
+	}
+	if result.HookSpecificOutput.UpdatedInput.Command != "gtkai git status" {
+		t.Fatalf("command %q", result.HookSpecificOutput.UpdatedInput.Command)
+	}
+}
+
+func TestPreLeavesEchoForCodex(t *testing.T) {
+	payload := `{"tool_name":"local_shell","tool_input":{"command":"echo hi"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentCodex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || out.Len() != 0 {
+		t.Fatalf("echo must pass through for codex, ok=%v out=%q", ok, out.String())
+	}
+}
+
+func TestPreLeavesGtkaiForCodex(t *testing.T) {
+	payload := `{"tool_name":"local_shell","tool_input":{"command":"gtkai git status"}}`
+	var out bytes.Buffer
+	ok, err := hook.RunPre(strings.NewReader(payload), &out, "gtkai", hook.AgentCodex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("already proxied command must not rewrite for codex")
+	}
+}
+
 func TestPreRewritesOpenCode(t *testing.T) {
 	payload := `{"tool_name":"bash","tool_input":{"command":"ls -la"}}`
 	var out bytes.Buffer


### PR DESCRIPTION
## Summary

- **`install.sh`**: `setup_codex()` no longer writes `[features] codex_hooks = true`. Codex 0.149.1 deprecated this flag — hooks now activate via `hooks.json` alone. On reinstall, the old flag is removed and the `[features]` header is dropped if it becomes empty.
- **`cmd/gtkai/install_test.go`**: `TestInstallCodex` now asserts `codex_hooks` is **absent** from `config.toml` instead of present.
- **`internal/hook/pre_test.go`**: Four new Codex-specific pre-tool-use tests — `hookEventName` field verification, `Bash` tool name coverage, and explicit passthrough cases.

## Why

The legacy flag was preventing Codex 0.149.1's new trust-store mechanism from recording the `pre_tool_use` hash in `[hooks.state]`. Because the hash was never stored, Codex re-prompted for trust on every session start (`codex doctor --json` also reported `legacy codex_hooks → hooks`).

## Test plan

- [x] `go test ./...` — all green
- [x] `sh install.sh --agent=codex` on a fresh home → no `codex_hooks` in `config.toml`
- [x] `sh install.sh --agent=codex` on a home with existing `codex_hooks` → flag removed
- [x] Restart Codex 0.149.1 → trust prompt appears once; `[hooks.state]` records `pre_tool_use` hash; no prompt on next start