### PR TITLE
feat(init): add gtkai init command and .gtk-ai project marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ claude plugin install -s user gtk-ai@gtk-ai
 
 Then restart the agent.
 
+### Activate in a project
+
+Hooks only run in projects where gtkai has been explicitly activated. Run once at the repo root:
+
+```bash
+gtkai init
+```
+
+This writes an empty `.gtk-ai` marker at the git root. Hooks silently skip directories that do not have the marker, so gtkai never activates in projects you did not opt in to.
+
 ### Option B: build from source
 
 Requires Go 1.22+.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Savings grow with output size. Small outputs may not be reduced.
 
 ## Installation
 
-gtk-ai requires the `gtkai` binary plus one integration per coding agent. The installer default is `--agent=auto`: it configures every compatible agent it finds on the machine.
+Installs the `gtkai` binary and configures hooks for every compatible agent found on the machine. Run once per machine.
 
 ### Option A: install script
 
@@ -69,16 +69,6 @@ claude plugin install -s user gtk-ai@gtk-ai
 
 Then restart the agent.
 
-### Activate in a project
-
-Hooks only run in projects where gtkai has been explicitly activated. Run once at the repo root:
-
-```bash
-gtkai init
-```
-
-This writes an empty `.gtk-ai` marker at the git root. Hooks silently skip directories that do not have the marker, so gtkai never activates in projects you did not opt in to.
-
 ### Option B: build from source
 
 Requires Go 1.22+.
@@ -102,6 +92,16 @@ GTKAI_SKIP_BINARY=1 sh install.sh -- --agent=all
 | **Hooks** | plugin `PreToolUse` / `PostToolUse` | `~/.cursor/hooks/` | `~/.codex/hooks/` | `~/.config/opencode/plugins/gtkai.ts` |
 | **Shell rewrite** | matcher `Bash` | matcher `Shell` | matcher `Bash` and shell aliases | `tool.execute.before` |
 | **Read / MCP post** | yes | MCP only | shell rewrite only | `read` and MCP tools |
+
+## Project activation
+
+Once installed, gtkai must be activated per project. Run once at the repo root:
+
+```bash
+gtkai init
+```
+
+This writes an empty `.gtk-ai` marker at the git root. Hooks silently skip any project without the marker — gtkai never activates where you did not opt in.
 
 ## Built-in modules
 

--- a/cmd/gtkai/init.go
+++ b/cmd/gtkai/init.go
@@ -8,34 +8,16 @@ import (
 )
 
 func runInit() {
-	dir := "."
-	for _, arg := range os.Args[2:] {
-		if arg == "--help" || arg == "-h" {
-			fmt.Fprintln(os.Stderr, "usage: gtkai init [--path=<dir>]")
-			return
-		}
-		if len(arg) > 7 && arg[:7] == "--path=" {
-			dir = arg[7:]
-		}
-	}
-
-	abs, err := absInitPath(dir)
+	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "gtkai init: %v\n", err)
 		os.Exit(1)
 	}
-	root := projectmarker.ProjectRoot(abs)
+	root := projectmarker.ProjectRoot(cwd)
 
 	if err := projectmarker.Create(root); err != nil {
 		fmt.Fprintf(os.Stderr, "gtkai init: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Printf("gtkai: marker written to %s/%s\n", root, projectmarker.MarkerName)
-}
-
-func absInitPath(dir string) (string, error) {
-	if dir == "." {
-		return os.Getwd()
-	}
-	return dir, nil
 }

--- a/cmd/gtkai/init.go
+++ b/cmd/gtkai/init.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/projectmarker"
+)
+
+func runInit() {
+	dir := "."
+	for _, arg := range os.Args[2:] {
+		if arg == "--help" || arg == "-h" {
+			fmt.Fprintln(os.Stderr, "usage: gtkai init [--path=<dir>]")
+			return
+		}
+		if len(arg) > 7 && arg[:7] == "--path=" {
+			dir = arg[7:]
+		}
+	}
+
+	abs, err := absInitPath(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gtkai init: %v\n", err)
+		os.Exit(1)
+	}
+	root := projectmarker.ProjectRoot(abs)
+
+	if err := projectmarker.Create(root); err != nil {
+		fmt.Fprintf(os.Stderr, "gtkai init: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("gtkai: marker written to %s/%s\n", root, projectmarker.MarkerName)
+}
+
+func absInitPath(dir string) (string, error) {
+	if dir == "." {
+		return os.Getwd()
+	}
+	return dir, nil
+}

--- a/cmd/gtkai/integration_test.go
+++ b/cmd/gtkai/integration_test.go
@@ -365,3 +365,28 @@ func TestIntegrationHookPreDateAlreadyProxied(t *testing.T) {
 		t.Fatalf("already proxied command must produce no rewrite output, got: %s", out)
 	}
 }
+
+func TestIntegrationInit(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+
+	out, code := run(t, bin, dir, "init", "--path="+dir)
+	if code != 0 {
+		t.Fatalf("gtkai init: exit %d, output:\n%s", code, out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gtk-ai")); err != nil {
+		t.Fatalf(".gtk-ai marker not created: %v", err)
+	}
+}
+
+func TestIntegrationInitIdempotent(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+
+	if _, code := run(t, bin, dir, "init", "--path="+dir); code != 0 {
+		t.Fatalf("first init failed")
+	}
+	if _, code := run(t, bin, dir, "init", "--path="+dir); code != 0 {
+		t.Fatalf("second init must not fail")
+	}
+}

--- a/cmd/gtkai/integration_test.go
+++ b/cmd/gtkai/integration_test.go
@@ -370,7 +370,7 @@ func TestIntegrationInit(t *testing.T) {
 	bin := buildBinary(t)
 	dir := t.TempDir()
 
-	out, code := run(t, bin, dir, "init", "--path="+dir)
+	out, code := run(t, bin, dir, "init")
 	if code != 0 {
 		t.Fatalf("gtkai init: exit %d, output:\n%s", code, out)
 	}
@@ -383,10 +383,10 @@ func TestIntegrationInitIdempotent(t *testing.T) {
 	bin := buildBinary(t)
 	dir := t.TempDir()
 
-	if _, code := run(t, bin, dir, "init", "--path="+dir); code != 0 {
+	if _, code := run(t, bin, dir, "init"); code != 0 {
 		t.Fatalf("first init failed")
 	}
-	if _, code := run(t, bin, dir, "init", "--path="+dir); code != 0 {
+	if _, code := run(t, bin, dir, "init"); code != 0 {
 		t.Fatalf("second init must not fail")
 	}
 }

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -36,6 +36,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s
 
 Usage:
+  gtkai init [--path=<dir>]        Activate gtkai in the current project (writes .gtk-ai marker)
   gtkai hook-pre --agent=<agent>   PreToolUse hook — rewrites shell commands to gtkai
   gtkai hook-post --agent=<agent>  PostToolUse hook — reads stdin, writes filtered output
   gtkai json-merge <file>          Deep-merge JSON from stdin into <file>
@@ -65,6 +66,9 @@ func main() {
 	switch os.Args[1] {
 	case "version", "--version", "-v":
 		fmt.Printf("gtkai %s\n", version)
+
+	case "init":
+		runInit()
 
 	case "hook-pre":
 		agent, err := parseAgentFlag(os.Args[2:])

--- a/cmd/gtkai/main.go
+++ b/cmd/gtkai/main.go
@@ -36,7 +36,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, `gtkai %s
 
 Usage:
-  gtkai init [--path=<dir>]        Activate gtkai in the current project (writes .gtk-ai marker)
+  gtkai init                       Activate gtkai in the current project (writes .gtk-ai marker)
   gtkai hook-pre --agent=<agent>   PreToolUse hook — rewrites shell commands to gtkai
   gtkai hook-post --agent=<agent>  PostToolUse hook — reads stdin, writes filtered output
   gtkai json-merge <file>          Deep-merge JSON from stdin into <file>

--- a/integrations/claude/scripts/gtkai-post-tool-use.sh
+++ b/integrations/claude/scripts/gtkai-post-tool-use.sh
@@ -13,4 +13,9 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
+
+# Only activate in projects that have run `gtkai init`.
+_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -f "$_root/.gtk-ai" ] || exit 0
+
 exec "$GTKAI" hook-post --agent=claudecode

--- a/integrations/claude/scripts/gtkai-pre-tool-use.sh
+++ b/integrations/claude/scripts/gtkai-pre-tool-use.sh
@@ -12,4 +12,9 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
+
+# Only activate in projects that have run `gtkai init`.
+_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -f "$_root/.gtk-ai" ] || exit 0
+
 exec "$GTKAI" hook-pre --agent=claudecode

--- a/integrations/codex/hooks/gtkai-pre-tool-use.sh
+++ b/integrations/codex/hooks/gtkai-pre-tool-use.sh
@@ -12,4 +12,9 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
+
+# Only activate in projects that have run `gtkai init`.
+_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -f "$_root/.gtk-ai" ] || exit 0
+
 exec "$GTKAI" hook-pre --agent=codex

--- a/integrations/cursor/hooks/gtkai-post-tool-use.sh
+++ b/integrations/cursor/hooks/gtkai-post-tool-use.sh
@@ -12,4 +12,9 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
+
+# Only activate in projects that have run `gtkai init`.
+_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -f "$_root/.gtk-ai" ] || exit 0
+
 exec "$GTKAI" hook-post --agent=cursor

--- a/integrations/cursor/hooks/gtkai-pre-tool-use.sh
+++ b/integrations/cursor/hooks/gtkai-pre-tool-use.sh
@@ -12,4 +12,9 @@ if [ -z "$GTKAI" ]; then
 fi
 
 [ -z "$GTKAI" ] && exit 0
+
+# Only activate in projects that have run `gtkai init`.
+_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -f "$_root/.gtk-ai" ] || exit 0
+
 exec "$GTKAI" hook-pre --agent=cursor

--- a/integrations/opencode/plugins/gtkai.ts
+++ b/integrations/opencode/plugins/gtkai.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import { existsSync } from "node:fs"
+import { spawnSync } from "node:child_process"
 
 function findGtkai(): string | null {
   const fromPath = Bun.which("gtkai")
@@ -14,6 +15,12 @@ function findGtkai(): string | null {
     if (existsSync(candidate)) return candidate
   }
   return null
+}
+
+function markerExists(): boolean {
+  const r = spawnSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" })
+  const root = r.status === 0 ? r.stdout.trim() : process.cwd()
+  return existsSync(`${root}/.gtk-ai`)
 }
 
 function runHook(gtkai: string, args: string[], payload: unknown): string {
@@ -33,6 +40,7 @@ export const GtkAI: Plugin = async () => {
     "tool.execute.before": async (input, output) => {
       argsByCall.set(input.callID, output.args as Record<string, unknown>)
       if (!gtkai) return
+      if (!markerExists()) return
       if (input.tool !== "bash" && input.tool !== "shell") return
       const command = (output.args as { command?: unknown }).command
       if (typeof command !== "string" || command === "") return
@@ -56,6 +64,7 @@ export const GtkAI: Plugin = async () => {
       const args = argsByCall.get(input.callID)
       argsByCall.delete(input.callID)
       if (!gtkai) return
+      if (!markerExists()) return
       if (args === undefined) return
       if (input.tool === "bash" || input.tool === "shell") return
       if (output.output === "") return

--- a/internal/projectmarker/marker.go
+++ b/internal/projectmarker/marker.go
@@ -1,0 +1,42 @@
+// Package projectmarker manages the .gtk-ai project marker.
+// The marker is an empty file that signals gtkai is active in the project.
+// Hooks exit immediately when it is absent.
+package projectmarker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const MarkerName = ".gtk-ai"
+
+// ProjectRoot returns the git root of dir, or dir itself when not in a repo.
+func ProjectRoot(dir string) string {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
+	if err == nil {
+		return strings.TrimSpace(string(out))
+	}
+	return dir
+}
+
+// Exists reports whether a .gtk-ai marker is present at root.
+func Exists(root string) bool {
+	_, err := os.Stat(filepath.Join(root, MarkerName))
+	return err == nil
+}
+
+// Create writes an empty .gtk-ai marker at root. Idempotent.
+func Create(root string) error {
+	path := filepath.Join(root, MarkerName)
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	return f.Close()
+}

--- a/internal/projectmarker/marker_test.go
+++ b/internal/projectmarker/marker_test.go
@@ -1,0 +1,54 @@
+package projectmarker_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmeiracorbal/gtk-ai/internal/projectmarker"
+)
+
+func TestExistsFalseWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if projectmarker.Exists(dir) {
+		t.Fatal("expected false for dir without marker")
+	}
+}
+
+func TestCreateWritesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := projectmarker.Create(dir); err != nil {
+		t.Fatal(err)
+	}
+	if !projectmarker.Exists(dir) {
+		t.Fatal("expected marker to exist after Create")
+	}
+	info, err := os.Stat(filepath.Join(dir, projectmarker.MarkerName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("marker must be empty, got %d bytes", info.Size())
+	}
+}
+
+func TestCreateIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := projectmarker.Create(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := projectmarker.Create(dir); err != nil {
+		t.Fatalf("second Create must not fail: %v", err)
+	}
+	if !projectmarker.Exists(dir) {
+		t.Fatal("marker must still exist after second Create")
+	}
+}
+
+func TestProjectRootFallsBackToDir(t *testing.T) {
+	dir := t.TempDir()
+	root := projectmarker.ProjectRoot(dir)
+	if root == "" {
+		t.Fatal("ProjectRoot must not return empty string")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `gtkai init` command that writes an empty `.gtk-ai` marker at the git root
- Hooks (Claude, Cursor, Codex, OpenCode) exit silently when the marker is absent — gtkai never activates in projects that did not opt in
- Follows the same pattern as mnemo's `.mnemo` marker: presence = enabled, no content needed
- Adds `internal/projectmarker` package with `Create`, `Exists`, and `ProjectRoot`
- Adds unit tests for `projectmarker` and integration tests for the `init` command
- Documents `gtkai init` in the README under Installation

## Test plan

- [x] `go test ./internal/projectmarker/` — all pass
- [x] `go test ./cmd/gtkai/ -run TestIntegrationInit` — all pass
- [x] `go test ./...` — full suite green
- [x] Manual: run `gtkai init` in a project, confirm `.gtk-ai` is created and hooks activate; confirm hooks are silent in a project without the marker